### PR TITLE
Today plan detail views with rotate and full Read Story

### DIFF
--- a/src/app/api/daily-brief/route.ts
+++ b/src/app/api/daily-brief/route.ts
@@ -83,6 +83,29 @@ export async function PATCH(request: Request) {
       return NextResponse.json({ brief });
     }
 
+    if (action === "regenerate-story") {
+      const brief = await regenerateDailyBriefSection(session.user.id, "story");
+      return NextResponse.json({ brief });
+    }
+
+    if (action === "regenerate-language") {
+      const brief = await regenerateDailyBriefSection(session.user.id, "language");
+      return NextResponse.json({ brief });
+    }
+
+    if (action === "save-activity") {
+      const brief = await getOrCreateDailyBrief(session.user.id);
+      const play = brief.play;
+      await prisma.familyMemory.create({
+        data: {
+          userId: session.user.id,
+          content: `Activity: ${play.title}\n${play.instructions.join(" ")}`,
+          category: "LEARNING",
+        },
+      });
+      return NextResponse.json({ brief });
+    }
+
     if (action === "save-recipe") {
       const brief = await getOrCreateDailyBrief(session.user.id);
       const recipe = brief.recipe;

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -7,17 +7,22 @@ import Link from 'next/link';
 import { Sun, UserPlus } from 'lucide-react';
 import { AppShell } from '@/components/layout/app-shell';
 import { Button } from '@/components/ui/button';
+import { TodaySectionHeader, TodayFocusCard, TodayConnectCard } from '@/components/today/today-cards';
+import { TodayPlanCard } from '@/components/today/today-plan-card';
+import { TodayBottomSheet } from '@/components/today/today-bottom-sheet';
 import {
-  TodayCompactCard,
-  TodaySectionHeader,
-  TodayFocusCard,
-  TodayConnectCard,
-} from '@/components/today/today-cards';
+  MealDetailView,
+  ActivityDetailView,
+  StoryDetailView,
+  LanguageDetailView,
+  getLanguageItem,
+} from '@/components/today/today-detail-views';
 import type { DailyBriefContent } from '@/types/daily-brief';
 import { getTimeGreeting } from '@/lib/constants';
 import { buildFocusCards, truncateWords } from '@/lib/today-focus';
 import { trackEvent, trackReturnVisit } from '@/lib/analytics';
 import { format } from 'date-fns';
+import { toast } from 'sonner';
 
 async function parseApiJson<T>(response: Response): Promise<T> {
   const text = await response.text();
@@ -28,6 +33,9 @@ async function parseApiJson<T>(response: Response): Promise<T> {
     throw new Error(`Invalid response (${response.status})`);
   }
 }
+
+type DetailType = 'meal' | 'activity' | 'story' | 'language' | null;
+type RotateSection = 'recipe' | 'play' | 'story' | 'language';
 
 interface ConnectEventPreview {
   id: string;
@@ -51,28 +59,14 @@ interface TodayData {
   upcomingEvent: ConnectEventPreview | null;
 }
 
-function milestoneSummary(brief: DailyBriefContent): { title: string; summary: string; detail: string } {
-  const dev = brief.development?.[0];
-  if (dev) {
-    return {
-      title: dev.domain,
-      summary: truncateWords(dev.tryToday || dev.insight, 12),
-      detail: `${dev.insight}\n\nTry today: ${dev.tryToday}`,
-    };
-  }
-  return {
-    title: brief.tip.topic,
-    summary: truncateWords(brief.tip.content, 12),
-    detail: brief.tip.content,
-  };
-}
-
 export default function TodayPage() {
   const { data: session, status } = useSession();
   const router = useRouter();
   const [data, setData] = useState<TodayData | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [activeDetail, setActiveDetail] = useState<DetailType>(null);
+  const [rotating, setRotating] = useState<RotateSection | null>(null);
 
   const loadToday = useCallback(() => {
     return Promise.all([
@@ -120,10 +114,44 @@ export default function TodayPage() {
     loadToday().finally(() => setLoading(false));
   }, [status, router, loadToday]);
 
+  const patchBrief = async (action: string, extra?: Record<string, unknown>) => {
+    const res = await fetch('/api/daily-brief', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action, ...extra }),
+    });
+    if (!res.ok) throw new Error('Request failed');
+    const json = await res.json();
+    if (json.brief) {
+      setData((prev) => (prev ? { ...prev, brief: json.brief } : prev));
+    }
+    return json;
+  };
+
+  const rotate = async (section: RotateSection) => {
+    const actionMap: Record<RotateSection, string> = {
+      recipe: 'regenerate-recipe',
+      play: 'regenerate-play',
+      story: 'regenerate-story',
+      language: 'regenerate-language',
+    };
+    setRotating(section);
+    try {
+      await patchBrief(actionMap[section]);
+      toast.success('Here\'s another idea!');
+    } catch {
+      toast.error('Could not rotate suggestion.');
+    } finally {
+      setRotating(null);
+    }
+  };
+
   const askMumbot = (prompt: string) => {
     sessionStorage.setItem('mumbot_prefill', prompt);
     router.push('/mumbot');
   };
+
+  const closeDetail = () => setActiveDetail(null);
 
   if (status === 'loading' || loading) {
     return (
@@ -146,7 +174,7 @@ export default function TodayPage() {
   const goals = data?.profile?.parentingGoals ?? [];
   const challenges = data?.profile?.currentChallenges ?? [];
   const focusCards = buildFocusCards(goals, challenges, data?.profile?.priorityGoal);
-  const milestone = brief ? milestoneSummary(brief) : null;
+  const languageItem = brief ? getLanguageItem(brief.development) : null;
 
   const connectAvailableText =
     data?.connectAvailableCount === 0
@@ -158,6 +186,13 @@ export default function TodayPage() {
   const upcomingText = data?.upcomingEvent
     ? `1 ${data.upcomingEvent.title.toLowerCase()} · ${data.upcomingEvent.broadArea} · ${format(new Date(data.upcomingEvent.date), 'EEE')}.`
     : 'No upcoming events — browse or create one.';
+
+  const detailTitles: Record<Exclude<DetailType, null>, string> = {
+    meal: 'Today\'s Meal',
+    activity: 'Today\'s Activity',
+    story: 'Read Story',
+    language: 'Language & Speech',
+  };
 
   return (
     <AppShell>
@@ -198,64 +233,61 @@ export default function TodayPage() {
 
         {brief && (
           <>
-            {/* Section 1: Today's Plan (70% age-based) */}
             <section className="space-y-2.5">
               <TodaySectionHeader emoji="🌟" title="Today's Plan" />
-              <TodayCompactCard
+              <TodayPlanCard
                 emoji="🍎"
                 label="Meal"
                 title={brief.recipe.subtitle}
-                summary={truncateWords(brief.recipe.whyThisMeal || brief.recipe.title, 12)}
-                ctaLabel="View"
-                onCta={() => trackEvent('meal_clicked')}
-                detail={
-                  <div className="space-y-2 text-xs">
-                    <p>{brief.recipe.whyThisMeal}</p>
-                    <ul className="list-disc pl-4">
-                      {brief.recipe.ingredients.slice(0, 6).map((i) => (
-                        <li key={i}>{i}</li>
-                      ))}
-                    </ul>
-                  </div>
-                }
+                preview={truncateWords(brief.recipe.whyThisMeal || brief.recipe.title, 15)}
+                ctaLabel="View Meal"
+                onOpen={() => {
+                  trackEvent('meal_clicked');
+                  setActiveDetail('meal');
+                }}
+                onRefresh={() => rotate('recipe')}
+                refreshing={rotating === 'recipe'}
               />
-              <TodayCompactCard
+              <TodayPlanCard
                 emoji="🎨"
                 label="Activity"
                 title={brief.play.title}
-                summary={truncateWords(brief.play.instructions[0] || brief.play.ageRecommendation || '', 12)}
-                ctaLabel="Start"
-                onCta={() => trackEvent('activity_clicked')}
-                detail={
-                  <ol className="list-decimal pl-4 text-xs space-y-1">
-                    {brief.play.instructions.map((step, i) => (
-                      <li key={i}>{step}</li>
-                    ))}
-                  </ol>
-                }
+                preview={truncateWords(brief.play.instructions[0] || 'A fun age-appropriate activity.', 15)}
+                ctaLabel="Start Activity"
+                onOpen={() => {
+                  trackEvent('activity_clicked');
+                  setActiveDetail('activity');
+                }}
+                onRefresh={() => rotate('play')}
+                refreshing={rotating === 'play'}
               />
-              <TodayCompactCard
+              <TodayPlanCard
                 emoji="📖"
                 label="Story"
                 title={brief.bedtimeStory.title}
-                summary={truncateWords(brief.bedtimeStory.moral || 'A bedtime tale for tonight.', 12)}
-                ctaLabel="Read"
-                onCta={() => trackEvent('story_clicked')}
-                detail={<p className="text-xs whitespace-pre-wrap leading-relaxed">{brief.bedtimeStory.story}</p>}
+                preview={truncateWords(brief.bedtimeStory.moral || 'A bedtime tale for tonight.', 15)}
+                ctaLabel="Read Story"
+                onOpen={() => {
+                  trackEvent('story_clicked');
+                  setActiveDetail('story');
+                }}
+                onRefresh={() => rotate('story')}
+                refreshing={rotating === 'story'}
               />
-              {milestone && (
-                <TodayCompactCard
-                  emoji="🌱"
-                  label="Milestone"
-                  title={milestone.title}
-                  summary={milestone.summary}
-                  ctaLabel="Learn"
-                  detail={<p className="text-xs whitespace-pre-wrap">{milestone.detail}</p>}
+              {languageItem && (
+                <TodayPlanCard
+                  emoji="💬"
+                  label="Language"
+                  title={languageItem.domain}
+                  preview={truncateWords(languageItem.tryToday || languageItem.insight, 15)}
+                  ctaLabel="Try Words"
+                  onOpen={() => setActiveDetail('language')}
+                  onRefresh={() => rotate('language')}
+                  refreshing={rotating === 'language'}
                 />
               )}
             </section>
 
-            {/* Section 2: Your Focus (30% goals/challenges) */}
             <section className="space-y-2.5">
               <TodaySectionHeader emoji="🎯" title="Your Focus" />
               {focusCards.length > 0 ? (
@@ -278,7 +310,6 @@ export default function TodayPage() {
               )}
             </section>
 
-            {/* Section 3: Connect */}
             <section className="space-y-2.5">
               <TodaySectionHeader emoji="👥" title="Connect" />
               <TodayConnectCard
@@ -299,6 +330,43 @@ export default function TodayPage() {
           </>
         )}
       </div>
+
+      <TodayBottomSheet
+        open={activeDetail !== null}
+        title={activeDetail ? detailTitles[activeDetail] : ''}
+        onClose={closeDetail}
+      >
+        {activeDetail === 'meal' && brief && (
+          <MealDetailView
+            recipe={brief.recipe}
+            childAgeDisplay={brief.childAgeDisplay}
+            onSave={() => patchBrief('save-recipe')}
+            onBack={closeDetail}
+          />
+        )}
+        {activeDetail === 'activity' && brief && (
+          <ActivityDetailView
+            play={brief.play}
+            onSave={() => patchBrief('save-activity')}
+            onBack={closeDetail}
+          />
+        )}
+        {activeDetail === 'story' && brief && (
+          <StoryDetailView
+            story={brief.bedtimeStory}
+            childAgeDisplay={brief.childAgeDisplay}
+            onSave={(extras) => patchBrief('save-story', extras)}
+            onBack={closeDetail}
+          />
+        )}
+        {activeDetail === 'language' && brief && languageItem && (
+          <LanguageDetailView
+            item={languageItem}
+            childAgeDisplay={brief.childAgeDisplay}
+            onBack={closeDetail}
+          />
+        )}
+      </TodayBottomSheet>
     </AppShell>
   );
 }

--- a/src/components/today/today-bottom-sheet.tsx
+++ b/src/components/today/today-bottom-sheet.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect } from 'react';
+import { X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface TodayBottomSheetProps {
+  open: boolean;
+  title: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export function TodayBottomSheet({ open, title, onClose, children }: TodayBottomSheetProps) {
+  useEffect(() => {
+    if (open) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col justify-end">
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/40"
+        aria-label="Close"
+        onClick={onClose}
+      />
+      <div
+        className={cn(
+          'relative bg-background rounded-t-3xl shadow-xl max-h-[88vh] flex flex-col',
+          'animate-in slide-in-from-bottom duration-300'
+        )}
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b shrink-0">
+          <h2 className="font-semibold text-base pr-2">{title}</h2>
+          <Button variant="ghost" size="icon" className="shrink-0 rounded-full" onClick={onClose}>
+            <X className="h-5 w-5" />
+          </Button>
+        </div>
+        <div className="overflow-y-auto px-4 py-4 pb-8 flex-1">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/today/today-detail-views.tsx
+++ b/src/components/today/today-detail-views.tsx
@@ -1,0 +1,358 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Bookmark, Volume2, Square, Loader2, ImageIcon } from 'lucide-react';
+import type {
+  DailyBriefRecipe,
+  DailyBriefPlay,
+  DailyBriefStory,
+  DailyBriefDevelopment,
+} from '@/types/daily-brief';
+import { toast } from 'sonner';
+
+interface DetailActionsProps {
+  onBack: () => void;
+}
+
+export function MealDetailView({
+  recipe,
+  childAgeDisplay,
+  onSave,
+  onBack,
+}: {
+  recipe: DailyBriefRecipe;
+  childAgeDisplay?: string;
+  onSave: () => Promise<void>;
+  onBack: () => void;
+} & DetailActionsProps) {
+  const [saving, setSaving] = useState(false);
+
+  return (
+    <div className="space-y-4 text-sm">
+      <div>
+        <h3 className="text-lg font-bold">{recipe.subtitle}</h3>
+        {childAgeDisplay && (
+          <p className="text-xs text-muted-foreground mt-1">Suitable for {childAgeDisplay}</p>
+        )}
+      </div>
+      <div>
+        <p className="text-xs font-medium uppercase text-muted-foreground mb-1">Why it helps</p>
+        <p className="leading-relaxed">{recipe.whyThisMeal}</p>
+      </div>
+      {recipe.healthyTip && (
+        <div className="bg-emerald-50 rounded-xl p-3 text-emerald-900">
+          <p className="text-xs font-medium mb-1">Picky eating tip</p>
+          <p className="text-sm">{recipe.healthyTip}</p>
+        </div>
+      )}
+      <div>
+        <p className="text-xs font-medium uppercase text-muted-foreground mb-2">Ingredients</p>
+        <ul className="list-disc pl-4 space-y-1 text-muted-foreground">
+          {recipe.ingredients.map((i) => (
+            <li key={i}>{i}</li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <p className="text-xs font-medium uppercase text-muted-foreground mb-2">Simple steps</p>
+        <ol className="list-decimal pl-4 space-y-2 text-muted-foreground">
+          {recipe.steps.map((step, i) => (
+            <li key={i}>{step}</li>
+          ))}
+        </ol>
+      </div>
+      <div className="flex gap-2 pt-2">
+        <Button
+          className="flex-1 rounded-full"
+          disabled={saving}
+          onClick={async () => {
+            setSaving(true);
+            try {
+              await onSave();
+              toast.success('Meal saved!');
+            } catch {
+              toast.error('Could not save meal.');
+            } finally {
+              setSaving(false);
+            }
+          }}
+        >
+          <Bookmark className="h-4 w-4 mr-1" />
+          {saving ? 'Saving...' : 'Save meal'}
+        </Button>
+        <Button variant="outline" className="rounded-full" onClick={onBack}>
+          Back to Today
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function ActivityDetailView({
+  play,
+  onSave,
+  onBack,
+}: {
+  play: DailyBriefPlay;
+  onSave: () => Promise<void>;
+  onBack: () => void;
+}) {
+  const [saving, setSaving] = useState(false);
+
+  return (
+    <div className="space-y-4 text-sm">
+      <div>
+        <h3 className="text-lg font-bold">{play.title}</h3>
+        <div className="flex flex-wrap gap-2 mt-2">
+          <Badge variant="secondary" className="rounded-full">{play.durationMinutes} min</Badge>
+          {play.ageRecommendation && (
+            <Badge variant="outline" className="rounded-full">{play.ageRecommendation}</Badge>
+          )}
+        </div>
+      </div>
+      <div>
+        <p className="text-xs font-medium uppercase text-muted-foreground mb-1">Materials</p>
+        <ul className="list-disc pl-4 text-muted-foreground">
+          {play.materials.map((m) => (
+            <li key={m}>{m}</li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <p className="text-xs font-medium uppercase text-muted-foreground mb-2">Steps</p>
+        <ol className="list-decimal pl-4 space-y-2 text-muted-foreground">
+          {play.instructions.map((step, i) => (
+            <li key={i}>{step}</li>
+          ))}
+        </ol>
+      </div>
+      {play.skillsDeveloped?.length > 0 && (
+        <div>
+          <p className="text-xs font-medium uppercase text-muted-foreground mb-1">Skills supported</p>
+          <p className="text-muted-foreground">{play.skillsDeveloped.join(' · ')}</p>
+        </div>
+      )}
+      <p className="text-xs bg-primary/5 rounded-xl p-3 text-muted-foreground">
+        Parent tip: Follow your child&apos;s lead — the goal is connection, not perfection.
+      </p>
+      <div className="flex gap-2 pt-2">
+        <Button
+          className="flex-1 rounded-full"
+          disabled={saving}
+          onClick={async () => {
+            setSaving(true);
+            try {
+              await onSave();
+              toast.success('Activity saved!');
+            } catch {
+              toast.error('Could not save activity.');
+            } finally {
+              setSaving(false);
+            }
+          }}
+        >
+          <Bookmark className="h-4 w-4 mr-1" />
+          {saving ? 'Saving...' : 'Save activity'}
+        </Button>
+        <Button variant="outline" className="rounded-full" onClick={onBack}>
+          Back to Today
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function StoryDetailView({
+  story,
+  childAgeDisplay,
+  onSave,
+  onBack,
+}: {
+  story: DailyBriefStory;
+  childAgeDisplay?: string;
+  onSave: (extras?: { illustrationData?: string }) => Promise<void>;
+  onBack: () => void;
+}) {
+  const [saving, setSaving] = useState(false);
+  const [illustrating, setIllustrating] = useState(false);
+  const [narrating, setNarrating] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [illustrationData, setIllustrationData] = useState<string | undefined>(story.illustrationData);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    setIllustrationData(story.illustrationData);
+  }, [story.illustrationData]);
+
+  const stopAudio = () => {
+    audioRef.current?.pause();
+    audioRef.current = null;
+    setIsPlaying(false);
+  };
+
+  const handleNarrate = async () => {
+    if (isPlaying) {
+      stopAudio();
+      return;
+    }
+    setNarrating(true);
+    try {
+      const res = await fetch('/api/stories/narrate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ story: story.story, cache: false }),
+      });
+      if (!res.ok) throw new Error();
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const audio = new Audio(url);
+      audioRef.current = audio;
+      audio.onended = () => {
+        setIsPlaying(false);
+        URL.revokeObjectURL(url);
+      };
+      await audio.play();
+      setIsPlaying(true);
+    } catch {
+      toast.error('Could not generate narration.');
+    } finally {
+      setNarrating(false);
+    }
+  };
+
+  const handleIllustrate = async () => {
+    setIllustrating(true);
+    try {
+      const res = await fetch('/api/stories/illustrate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: story.title, story: story.story, moral: story.moral }),
+      });
+      if (!res.ok) throw new Error();
+      const { illustrationData: data } = await res.json();
+      setIllustrationData(data);
+      toast.success('Cover ready!');
+    } catch {
+      toast.error('Could not generate illustration.');
+    } finally {
+      setIllustrating(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4 text-sm">
+      <div>
+        <h3 className="text-lg font-bold">{story.title}</h3>
+        <div className="flex flex-wrap gap-2 mt-2">
+          <Badge variant="secondary" className="rounded-full">~{story.lengthMinutes} min read</Badge>
+          {childAgeDisplay && (
+            <Badge variant="outline" className="rounded-full">{childAgeDisplay}</Badge>
+          )}
+        </div>
+      </div>
+      {illustrationData && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={illustrationData} alt="" className="w-full rounded-2xl max-h-48 object-cover" />
+      )}
+      {story.moral && (
+        <p className="text-xs text-primary/80 bg-primary/5 rounded-xl px-3 py-2">
+          Theme: {story.moral}
+        </p>
+      )}
+      <p className="text-xs text-muted-foreground bg-muted/40 rounded-xl px-3 py-2">
+        Parent tip: Use a calm voice and pause for your child to react — stories build language and connection.
+      </p>
+      <div className="text-base leading-relaxed text-foreground whitespace-pre-line bg-muted/30 rounded-2xl p-4 max-h-[40vh] overflow-y-auto">
+        {story.story}
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <Button size="sm" variant="outline" className="rounded-full" disabled={illustrating} onClick={handleIllustrate}>
+          {illustrating ? <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" /> : <ImageIcon className="h-3.5 w-3.5 mr-1" />}
+          Cover art
+        </Button>
+        <Button size="sm" variant="outline" className="rounded-full" disabled={narrating && !isPlaying} onClick={handleNarrate}>
+          {isPlaying ? <Square className="h-3.5 w-3.5 mr-1" /> : narrating ? <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" /> : <Volume2 className="h-3.5 w-3.5 mr-1" />}
+          {isPlaying ? 'Stop' : 'Listen'}
+        </Button>
+      </div>
+      <div className="flex gap-2 pt-2">
+        <Button
+          className="flex-1 rounded-full"
+          disabled={saving}
+          onClick={async () => {
+            setSaving(true);
+            try {
+              await onSave({ illustrationData });
+              toast.success('Story saved!');
+            } catch {
+              toast.error('Could not save story.');
+            } finally {
+              setSaving(false);
+            }
+          }}
+        >
+          <Bookmark className="h-4 w-4 mr-1" />
+          {saving ? 'Saving...' : 'Save story'}
+        </Button>
+        <Button variant="outline" className="rounded-full" onClick={onBack}>
+          Back to Today
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function LanguageDetailView({
+  item,
+  childAgeDisplay,
+  onBack,
+}: {
+  item: DailyBriefDevelopment;
+  childAgeDisplay?: string;
+  onBack: () => void;
+}) {
+  return (
+    <div className="space-y-4 text-sm">
+      <div>
+        <h3 className="text-lg font-bold flex items-center gap-2">
+          <span>{item.icon ?? '💬'}</span>
+          {item.domain}
+        </h3>
+        {childAgeDisplay && (
+          <p className="text-xs text-muted-foreground mt-1">For {childAgeDisplay}</p>
+        )}
+      </div>
+      <div>
+        <p className="text-xs font-medium uppercase text-muted-foreground mb-1">Target words &amp; phrases</p>
+        <p className="leading-relaxed">{item.tryToday}</p>
+      </div>
+      <div>
+        <p className="text-xs font-medium uppercase text-muted-foreground mb-1">How to practice</p>
+        <p className="text-muted-foreground leading-relaxed">{item.tryToday}</p>
+      </div>
+      <div>
+        <p className="text-xs font-medium uppercase text-muted-foreground mb-1">Example game</p>
+        <p className="text-muted-foreground">Repeat words during everyday moments — bath time, meals, or play.</p>
+      </div>
+      <div>
+        <p className="text-xs font-medium uppercase text-muted-foreground mb-1">Skill supported</p>
+        <p className="text-muted-foreground">{item.domain} development</p>
+      </div>
+      <div className="bg-sky-50 rounded-xl p-3 text-sky-900">
+        <p className="text-xs font-medium mb-1">Parent tip</p>
+        <p className="text-sm leading-relaxed">{item.insight}</p>
+      </div>
+      <Button variant="outline" className="w-full rounded-full" onClick={onBack}>
+        Back to Today
+      </Button>
+    </div>
+  );
+}
+
+export function getLanguageItem(development: DailyBriefDevelopment[]): DailyBriefDevelopment {
+  return (
+    development.find((d) => /language|speech/i.test(d.domain)) ?? development[0]
+  );
+}

--- a/src/components/today/today-plan-card.tsx
+++ b/src/components/today/today-plan-card.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface TodayPlanCardProps {
+  emoji: string;
+  label: string;
+  title: string;
+  preview: string;
+  ctaLabel: string;
+  onOpen: () => void;
+  onRefresh?: () => void;
+  refreshing?: boolean;
+  className?: string;
+}
+
+export function TodayPlanCard({
+  emoji,
+  label,
+  title,
+  preview,
+  ctaLabel,
+  onOpen,
+  onRefresh,
+  refreshing,
+  className,
+}: TodayPlanCardProps) {
+  return (
+    <article className={cn('visual-card p-3.5', className)}>
+      <div className="flex items-start gap-3">
+        <button
+          type="button"
+          className="flex-1 min-w-0 text-left"
+          onClick={onOpen}
+        >
+          <span className="text-xl block mb-1" aria-hidden>{emoji}</span>
+          <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">{label}</p>
+          <p className="font-semibold text-sm leading-snug mt-0.5">{title}</p>
+          <p className="text-xs text-muted-foreground leading-relaxed mt-1 line-clamp-2">{preview}</p>
+        </button>
+        <div className="flex flex-col gap-2 shrink-0">
+          <Button
+            size="sm"
+            className="rounded-full h-9 px-3 text-xs touch-target"
+            onClick={onOpen}
+          >
+            {ctaLabel}
+          </Button>
+          {onRefresh && (
+            <Button
+              size="sm"
+              variant="ghost"
+              className="rounded-full h-8 px-2 text-[10px] text-muted-foreground"
+              disabled={refreshing}
+              onClick={(e) => {
+                e.stopPropagation();
+                onRefresh();
+              }}
+            >
+              <RefreshCw className={cn('h-3 w-3 mr-1', refreshing && 'animate-spin')} />
+              Try another
+            </Button>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/lib/services/daily-brief.ts
+++ b/src/lib/services/daily-brief.ts
@@ -1,8 +1,8 @@
 import { prisma } from "@/lib/db";
-import { defaultDailyBrief, generateDailyBrief, regeneratePlay, regenerateRecipe } from "@/lib/services/mumbot";
+import { defaultDailyBrief, generateDailyBrief, regeneratePlay, regenerateRecipe, regenerateStory, regenerateLanguage } from "@/lib/services/mumbot";
 import { fetchWeatherForLocation } from "@/lib/services/weather";
 import { toDateKey, yesterdayDateKey } from "@/lib/date-utils";
-import type { DailyBriefContent, DailyBriefPlay, DailyBriefRecipe } from "@/types/daily-brief";
+import type { DailyBriefContent, DailyBriefPlay, DailyBriefRecipe, DailyBriefStory, DailyBriefDevelopment } from "@/types/daily-brief";
 import { enrichBriefWithIllustrations, needsBriefIllustrations, type IllustrationSection } from "@/lib/services/card-illustrations";
 import type { BriefProfile } from "@/lib/daily-brief-context";
 
@@ -140,8 +140,8 @@ export async function getOrCreateDailyBrief(userId: string): Promise<DailyBriefC
 
 export async function updateDailyBriefSection(
   userId: string,
-  section: "recipe" | "play",
-  value: DailyBriefRecipe | DailyBriefPlay
+  section: "recipe" | "play" | "story" | "language",
+  value: DailyBriefRecipe | DailyBriefPlay | DailyBriefStory | DailyBriefDevelopment
 ) {
   const today = toDateKey();
   const existing = await prisma.dailyBrief.findUnique({
@@ -159,6 +159,18 @@ export async function updateDailyBriefSection(
   const content = brief!.content as unknown as DailyBriefContent;
   if (section === "recipe") content.recipe = value as DailyBriefRecipe;
   if (section === "play") content.play = value as DailyBriefPlay;
+  if (section === "story") {
+    content.bedtimeStory = value as DailyBriefStory;
+    delete content.bedtimeStory.illustrationData;
+  }
+  if (section === "language") {
+    const lang = value as DailyBriefDevelopment;
+    const idx = content.development.findIndex((d) =>
+      /language|speech/i.test(d.domain)
+    );
+    if (idx >= 0) content.development[idx] = lang;
+    else content.development.unshift(lang);
+  }
 
   await prisma.dailyBrief.update({
     where: { userId_date: { userId, date: today } },
@@ -168,7 +180,10 @@ export async function updateDailyBriefSection(
   return content;
 }
 
-export async function regenerateDailyBriefSection(userId: string, section: "recipe" | "play") {
+export async function regenerateDailyBriefSection(
+  userId: string,
+  section: "recipe" | "play" | "story" | "language"
+) {
   const today = toDateKey();
   let brief = await prisma.dailyBrief.findUnique({
     where: { userId_date: { userId, date: today } },
@@ -191,9 +206,23 @@ export async function regenerateDailyBriefSection(userId: string, section: "reci
     return updateDailyBriefSection(userId, "recipe", recipe);
   }
 
-  const play = await regeneratePlay(profile, memories, content.play, weather?.weather ?? null);
-  delete play.imageData;
-  return updateDailyBriefSection(userId, "play", play);
+  if (section === "play") {
+    const play = await regeneratePlay(profile, memories, content.play, weather?.weather ?? null);
+    delete play.imageData;
+    return updateDailyBriefSection(userId, "play", play);
+  }
+
+  if (section === "story") {
+    const story = await regenerateStory(profile, memories, content.bedtimeStory);
+    delete story.illustrationData;
+    return updateDailyBriefSection(userId, "story", story);
+  }
+
+  const languageItem =
+    content.development.find((d) => /language|speech/i.test(d.domain)) ??
+    content.development[0];
+  const language = await regenerateLanguage(profile, memories, languageItem);
+  return updateDailyBriefSection(userId, "language", language);
 }
 
 export async function getYesterdayJournalMemory(userId: string) {

--- a/src/lib/services/mumbot.ts
+++ b/src/lib/services/mumbot.ts
@@ -3,7 +3,7 @@ import { MemoryCategory } from "@prisma/client";
 import { generateParentingTipStatic } from "@/lib/mumbot-messages";
 import { OPENAI_MODEL, OPENAI_TEMPERATURE, OPENAI_MAX_TOKENS } from "@/lib/openai-config";
 import { buildDailyBriefContext, type BriefProfile, type BriefMemory } from "@/lib/daily-brief-context";
-import type { DailyBriefContent, DailyBriefRecipe, DailyBriefPlay, LibraryRecommendation, WeatherInfo } from "@/types/daily-brief";
+import type { DailyBriefContent, DailyBriefRecipe, DailyBriefPlay, DailyBriefStory, DailyBriefDevelopment, LibraryRecommendation, WeatherInfo } from "@/types/daily-brief";
 import { weatherContextLine } from "@/lib/services/weather";
 
 const openai = new OpenAI({
@@ -427,7 +427,7 @@ export async function regeneratePlay(
     messages: [
       {
         role: "system",
-        content: `Generate ONE new personalised play activity as JSON: { "title", "materials": [], "instructions": [], "skillsDeveloped": [], "durationMinutes", "indoorOutdoor" }. ${BRIEF_TONE_RULES}${avoid}`,
+        content: `Generate ONE new personalised play activity as JSON: { "title", "materials": [], "instructions": [], "skillsDeveloped": [], "durationMinutes", "indoorOutdoor", "ageRecommendation" }. ${BRIEF_TONE_RULES}${avoid}`,
       },
       { role: "user", content: context },
     ],
@@ -440,6 +440,66 @@ export async function regeneratePlay(
     return JSON.parse(completion.choices[0]?.message?.content || "{}") as DailyBriefPlay;
   } catch {
     return defaultDailyBrief(profile).play;
+  }
+}
+
+export async function regenerateStory(
+  profile: BriefProfile,
+  memories: BriefMemory[],
+  currentStory?: DailyBriefStory
+): Promise<DailyBriefStory> {
+  const context = buildDailyBriefContext(profile, memories, []);
+  const avoid = currentStory ? `\nAvoid repeating title or plot: ${currentStory.title}` : "";
+  const child = profile.childNickname || "the child";
+
+  const completion = await openai.chat.completions.create({
+    model: OPENAI_MODEL,
+    messages: [
+      {
+        role: "system",
+        content: `Generate ONE new personalised bedtime story as JSON: { "title", "story": "full story text 3-5 min read", "lengthMinutes": 5, "moral": "gentle moral" }. ${child} is the hero. ${BRIEF_TONE_RULES}${avoid}`,
+      },
+      { role: "user", content: context },
+    ],
+    temperature: 0.9,
+    max_tokens: 1200,
+    response_format: { type: "json_object" },
+  });
+
+  try {
+    return JSON.parse(completion.choices[0]?.message?.content || "{}") as DailyBriefStory;
+  } catch {
+    return defaultDailyBrief(profile).bedtimeStory;
+  }
+}
+
+export async function regenerateLanguage(
+  profile: BriefProfile,
+  memories: BriefMemory[],
+  current?: DailyBriefDevelopment
+): Promise<DailyBriefDevelopment> {
+  const context = buildDailyBriefContext(profile, memories, []);
+  const avoid = current ? `\nAvoid repeating: ${current.tryToday}` : "";
+
+  const completion = await openai.chat.completions.create({
+    model: OPENAI_MODEL,
+    messages: [
+      {
+        role: "system",
+        content: `Generate ONE language/speech development focus as JSON: { "domain": "Language", "icon": "💬", "insight": "Many children around this age...", "tryToday": "practical words/phrases or game to try today" }. Focus on speech, language, communication. ${BRIEF_TONE_RULES}${avoid}`,
+      },
+      { role: "user", content: context },
+    ],
+    temperature: 0.9,
+    max_tokens: 500,
+    response_format: { type: "json_object" },
+  });
+
+  try {
+    return JSON.parse(completion.choices[0]?.message?.content || "{}") as DailyBriefDevelopment;
+  } catch {
+    const fallback = defaultDailyBrief(profile).development[0];
+    return fallback;
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Keeps the Today dashboard glanceable while adding progressive disclosure for Story, Meal, Activity, and Language plan cards.

- **Preview cards** show icon, title, short preview, specific CTA, and a **Try another** refresh button
- **Bottom sheets** open rich detail views on tap without lengthening the Today page
- **Read Story** retains the full experience: full text, narration, cover art, and save
- **Rotate API** supports age-appropriate regeneration for recipe, play, story, and language sections

## Changes

### Today UI
- New `TodayPlanCard` for compact previews with CTAs (View Meal, Start Activity, Read Story, Try Words)
- New `TodayBottomSheet` for mobile-friendly detail overlays
- New detail views: meal, activity, story (full read flow), language/speech
- Language card replaces milestone in Today's Plan section
- Focus and Connect sections unchanged

### API / services
- `regenerate-story` and `regenerate-language` PATCH actions
- `save-activity` action (FamilyMemory)
- `regenerateStory()` and `regenerateLanguage()` in MumBot service

## UX principle

One card = short preview. Tap = full useful content.

## Test plan

- [ ] Visit `/today` — four plan cards show preview + CTA + Try another
- [ ] Tap each card — bottom sheet opens with full content
- [ ] Story: read full text, listen, generate cover, save
- [ ] Try another rotates suggestion and updates preview
- [ ] Focus and Connect sections still render correctly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a231d1e6-caff-4d6d-acd3-83f350fa4fb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a231d1e6-caff-4d6d-acd3-83f350fa4fb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

