### PR TITLE
Fix story Listen/Stop on Today and saved stories

### DIFF
--- a/src/app/saved/page.tsx
+++ b/src/app/saved/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, Suspense } from 'react';
 import { useSession } from 'next-auth/react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { AppShell } from '@/components/layout/app-shell';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -15,6 +15,7 @@ import {
 import type { DailyBriefRecipe } from '@/types/daily-brief';
 import { format } from 'date-fns';
 import { toast } from 'sonner';
+import { unlockStoryAudio, useStoryAudio } from '@/hooks/use-story-audio';
 
 interface SavedRecipe {
   id: string;
@@ -35,18 +36,29 @@ interface SavedStory {
 
 type Tab = 'recipes' | 'stories';
 
-export default function SavedPage() {
+function SavedPageContent() {
   const { status } = useSession();
   const router = useRouter();
-  const [tab, setTab] = useState<Tab>('recipes');
+  const searchParams = useSearchParams();
+  const [tab, setTab] = useState<Tab>(
+    searchParams.get('tab') === 'stories' ? 'stories' : 'recipes'
+  );
   const [recipes, setRecipes] = useState<SavedRecipe[]>([]);
   const [stories, setStories] = useState<SavedStory[]>([]);
   const [loading, setLoading] = useState(true);
   const [expandedRecipe, setExpandedRecipe] = useState<string | null>(null);
   const [expandedStory, setExpandedStory] = useState<string | null>(null);
-  const [busyId, setBusyId] = useState<string | null>(null);
-  const audioRef = useRef<HTMLAudioElement | null>(null);
-  const [playingId, setPlayingId] = useState<string | null>(null);
+  const [illustratingId, setIllustratingId] = useState<string | null>(null);
+  const [activeStoryId, setActiveStoryId] = useState<string | null>(null);
+  const activeStoryIdRef = useRef<string | null>(null);
+
+  const storyAudio = useStoryAudio({
+    onError: (message) => toast.error(message),
+    onIdle: () => {
+      activeStoryIdRef.current = null;
+      setActiveStoryId(null);
+    },
+  });
 
   const load = () => {
     Promise.all([
@@ -66,10 +78,15 @@ export default function SavedPage() {
     if (status === 'authenticated') load();
   }, [status, router]);
 
-  const stopAudio = () => {
-    audioRef.current?.pause();
-    audioRef.current = null;
-    setPlayingId(null);
+  useEffect(() => {
+    const nextTab = searchParams.get('tab') === 'stories' ? 'stories' : 'recipes';
+    setTab(nextTab);
+  }, [searchParams]);
+
+  const stopStoryAudio = () => {
+    storyAudio.stop();
+    activeStoryIdRef.current = null;
+    setActiveStoryId(null);
   };
 
   const deleteRecipe = async (id: string) => {
@@ -79,14 +96,14 @@ export default function SavedPage() {
   };
 
   const deleteStory = async (id: string) => {
-    if (playingId === id) stopAudio();
+    if (activeStoryIdRef.current === id) stopStoryAudio();
     await fetch(`/api/saved/stories/${id}`, { method: 'DELETE' });
     setStories((prev) => prev.filter((s) => s.id !== id));
     toast.success('Story removed');
   };
 
   const illustrateStory = async (story: SavedStory) => {
-    setBusyId(story.id);
+    setIllustratingId(story.id);
     try {
       const res = await fetch('/api/stories/illustrate', {
         method: 'POST',
@@ -102,35 +119,25 @@ export default function SavedPage() {
     } catch {
       toast.error('Could not generate illustration.');
     } finally {
-      setBusyId(null);
+      setIllustratingId(null);
     }
   };
 
-  const playStory = async (story: SavedStory) => {
-    if (playingId === story.id) {
-      stopAudio();
+  const toggleStoryAudio = (story: SavedStory) => {
+    if (activeStoryIdRef.current === story.id && storyAudio.isActive) {
+      stopStoryAudio();
       return;
     }
-    stopAudio();
-    setBusyId(story.id);
-    try {
-      const res = await fetch(`/api/saved/stories/${story.id}/audio`);
-      if (!res.ok) throw new Error();
-      const blob = await res.blob();
-      const url = URL.createObjectURL(blob);
-      const audio = new Audio(url);
-      audioRef.current = audio;
-      audio.onended = () => {
-        setPlayingId(null);
-        URL.revokeObjectURL(url);
-      };
-      await audio.play();
-      setPlayingId(story.id);
-    } catch {
-      toast.error('Could not play narration.');
-    } finally {
-      setBusyId(null);
-    }
+
+    stopStoryAudio();
+    activeStoryIdRef.current = story.id;
+    setActiveStoryId(story.id);
+
+    void storyAudio.toggle(async (signal) => {
+      const res = await fetch(`/api/saved/stories/${story.id}/audio`, { signal });
+      if (!res.ok) throw new Error('Audio failed');
+      return res.blob();
+    });
   };
 
   if (status === 'loading' || loading) {
@@ -143,7 +150,7 @@ export default function SavedPage() {
 
   return (
     <AppShell>
-      <div className="container max-w-lg mx-auto p-4 space-y-4">
+      <div className="container max-w-lg mx-auto p-4 space-y-4 pb-24">
         <div className="flex items-center gap-3 pt-2">
           <Link href="/today">
             <Button variant="ghost" size="icon" className="h-9 w-9">
@@ -246,7 +253,8 @@ export default function SavedPage() {
           ) : (
             stories.map((item) => {
               const open = expandedStory === item.id;
-              const isBusy = busyId === item.id;
+              const isIllustrating = illustratingId === item.id;
+              const isAudioActive = activeStoryId === item.id && storyAudio.isActive;
               return (
                 <Card key={item.id} className="rounded-2xl">
                   {item.illustrationData && (
@@ -299,11 +307,12 @@ export default function SavedPage() {
                       <Button
                         size="sm"
                         variant="outline"
-                        className="rounded-xl"
-                        disabled={isBusy}
+                        className="rounded-xl touch-target"
+                        type="button"
+                        disabled={isIllustrating}
                         onClick={() => illustrateStory(item)}
                       >
-                        {isBusy && !playingId ? (
+                        {isIllustrating ? (
                           <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
                         ) : (
                           <ImageIcon className="h-3.5 w-3.5 mr-1" />
@@ -312,19 +321,24 @@ export default function SavedPage() {
                       </Button>
                       <Button
                         size="sm"
-                        variant="outline"
-                        className="rounded-xl"
-                        disabled={isBusy && playingId !== item.id}
-                        onClick={() => playStory(item)}
+                        variant={isAudioActive ? 'default' : 'outline'}
+                        className="rounded-xl touch-target"
+                        type="button"
+                        onPointerDown={(e) => {
+                          e.stopPropagation();
+                          unlockStoryAudio();
+                        }}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          toggleStoryAudio(item);
+                        }}
                       >
-                        {playingId === item.id ? (
+                        {isAudioActive ? (
                           <Square className="h-3.5 w-3.5 mr-1" />
-                        ) : isBusy ? (
-                          <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
                         ) : (
                           <Volume2 className="h-3.5 w-3.5 mr-1" />
                         )}
-                        {playingId === item.id ? 'Stop' : 'Listen'}
+                        {isAudioActive ? 'Stop' : 'Listen'}
                       </Button>
                     </div>
                   </CardContent>
@@ -335,5 +349,17 @@ export default function SavedPage() {
         )}
       </div>
     </AppShell>
+  );
+}
+
+export default function SavedPage() {
+  return (
+    <Suspense fallback={
+      <AppShell>
+        <div className="container max-w-lg mx-auto p-6 text-center text-muted-foreground">Loading...</div>
+      </AppShell>
+    }>
+      <SavedPageContent />
+    </Suspense>
   );
 }

--- a/src/components/today/today-bottom-sheet.tsx
+++ b/src/components/today/today-bottom-sheet.tsx
@@ -58,7 +58,7 @@ export function TodayBottomSheet({ open, title, onClose, children, footer }: Tod
       />
       <div
         className={cn(
-          'relative bg-background rounded-t-3xl shadow-xl flex flex-col min-h-0',
+          'relative z-10 bg-background rounded-t-3xl shadow-xl flex flex-col min-h-0',
           'max-h-[min(88dvh,calc(100dvh-1rem))]',
           'animate-in slide-in-from-bottom duration-300'
         )}

--- a/src/components/today/today-detail-views.tsx
+++ b/src/components/today/today-detail-views.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, useState, useRef, useEffect, useCallback } from 'react';
+import { createContext, useContext, useState, useRef, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Bookmark, Volume2, Square, Loader2, ImageIcon } from 'lucide-react';
@@ -11,6 +11,7 @@ import type {
   DailyBriefDevelopment,
 } from '@/types/daily-brief';
 import { toast } from 'sonner';
+import { unlockStoryAudio, useStoryAudio } from '@/hooks/use-story-audio';
 
 type DetailPart = 'content' | 'footer';
 
@@ -184,7 +185,7 @@ export function ActivityDetailView({
   );
 }
 
-type StoryDetailContextValue = ReturnType<typeof useStoryDetailMedia> & {
+type StoryDetailContextValue = Omit<ReturnType<typeof useStoryDetailMedia>, never> & {
   story: DailyBriefStory;
   onSave: (extras?: { illustrationData?: string }) => Promise<void>;
   onBack: () => void;
@@ -223,77 +224,34 @@ export function StoryDetailProvider({
 
 function useStoryDetailMedia(story: DailyBriefStory) {
   const [illustrating, setIllustrating] = useState(false);
-  const [narrating, setNarrating] = useState(false);
-  const [isPlaying, setIsPlaying] = useState(false);
   const [illustrationData, setIllustrationData] = useState<string | undefined>(
     normalizeIllustrationSrc(story.illustrationData)
   );
-  const audioRef = useRef<HTMLAudioElement | null>(null);
-  const audioUrlRef = useRef<string | null>(null);
-  const abortRef = useRef<AbortController | null>(null);
   const coverRef = useRef<HTMLDivElement | null>(null);
+
+  const storyAudio = useStoryAudio({
+    onError: (message) => toast.error(message),
+  });
 
   useEffect(() => {
     setIllustrationData(normalizeIllustrationSrc(story.illustrationData));
   }, [story.illustrationData]);
 
-  const stopAudio = useCallback(() => {
-    abortRef.current?.abort();
-    abortRef.current = null;
-    if (audioRef.current) {
-      audioRef.current.pause();
-      audioRef.current.currentTime = 0;
-      audioRef.current = null;
-    }
-    if (audioUrlRef.current) {
-      URL.revokeObjectURL(audioUrlRef.current);
-      audioUrlRef.current = null;
-    }
-    setIsPlaying(false);
-    setNarrating(false);
-  }, []);
+  useEffect(() => {
+    storyAudio.stop();
+  }, [story.title, story.story]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => () => stopAudio(), [stopAudio]);
-
-  const handleNarrate = async () => {
-    if (isPlaying || narrating) {
-      stopAudio();
-      return;
-    }
-    setNarrating(true);
-    const controller = new AbortController();
-    abortRef.current = controller;
-    try {
+  const handleNarrate = () => {
+    void storyAudio.toggle(async (signal) => {
       const res = await fetch('/api/stories/narrate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ story: story.story, cache: false }),
-        signal: controller.signal,
+        signal,
       });
-      if (!res.ok) throw new Error();
-      const blob = await res.blob();
-      if (controller.signal.aborted) return;
-      const url = URL.createObjectURL(blob);
-      audioUrlRef.current = url;
-      const audio = new Audio(url);
-      audioRef.current = audio;
-      audio.onended = () => {
-        setIsPlaying(false);
-        if (audioUrlRef.current) {
-          URL.revokeObjectURL(audioUrlRef.current);
-          audioUrlRef.current = null;
-        }
-        audioRef.current = null;
-      };
-      await audio.play();
-      setIsPlaying(true);
-    } catch (err) {
-      if (err instanceof DOMException && err.name === 'AbortError') return;
-      toast.error('Could not generate narration.');
-    } finally {
-      if (abortRef.current === controller) abortRef.current = null;
-      setNarrating(false);
-    }
+      if (!res.ok) throw new Error('Narration failed');
+      return res.blob();
+    });
   };
 
   const handleIllustrate = async () => {
@@ -321,13 +279,14 @@ function useStoryDetailMedia(story: DailyBriefStory) {
 
   return {
     illustrating,
-    narrating,
-    isPlaying,
+    isPlaying: storyAudio.isPlaying,
+    isNarrating: storyAudio.isActive,
     illustrationData,
     coverRef,
     handleNarrate,
     handleIllustrate,
-    stopAudio,
+    stopAudio: storyAudio.stop,
+    unlockAudio: unlockStoryAudio,
   };
 }
 
@@ -368,15 +327,15 @@ export function StoryDetailFooter() {
     saving,
     setSaving,
     illustrating,
-    narrating,
-    isPlaying,
+    isNarrating,
     illustrationData,
     coverRef,
     handleNarrate,
     handleIllustrate,
     stopAudio,
+    unlockAudio,
   } = useStoryDetailContext();
-  const mediaActive = isPlaying || narrating;
+  const mediaActive = isNarrating;
 
   return (
     <div className="space-y-3">
@@ -412,14 +371,22 @@ export function StoryDetailFooter() {
             size="sm"
             variant={mediaActive ? 'default' : 'outline'}
             className="rounded-full touch-target"
-            onClick={handleNarrate}
+            type="button"
+            onPointerDown={(e) => {
+              e.stopPropagation();
+              unlockAudio();
+            }}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleNarrate();
+            }}
           >
             {mediaActive ? (
               <Square className="h-3.5 w-3.5 mr-1" />
             ) : (
               <Volume2 className="h-3.5 w-3.5 mr-1" />
             )}
-            {narrating && !isPlaying ? 'Stop' : isPlaying ? 'Stop' : 'Listen'}
+            {mediaActive ? 'Stop' : 'Listen'}
           </Button>
         </div>
       </div>

--- a/src/hooks/use-story-audio.ts
+++ b/src/hooks/use-story-audio.ts
@@ -1,0 +1,152 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type StoryAudioStatus = 'idle' | 'loading' | 'playing';
+
+let sharedAudioContext: AudioContext | null = null;
+
+/** Resume audio context synchronously inside a user gesture (required on iOS). */
+export function unlockStoryAudio() {
+  if (typeof window === 'undefined') return;
+  try {
+    sharedAudioContext ??= new AudioContext();
+    if (sharedAudioContext.state === 'suspended') {
+      void sharedAudioContext.resume();
+    }
+  } catch {
+    // Ignore — HTMLAudio fallback may still work.
+  }
+}
+
+interface UseStoryAudioOptions {
+  onError?: (message: string) => void;
+  onIdle?: () => void;
+}
+
+export function useStoryAudio(options: UseStoryAudioOptions = {}) {
+  const { onError, onIdle } = options;
+  const [status, setStatus] = useState<StoryAudioStatus>('idle');
+  const statusRef = useRef<StoryAudioStatus>('idle');
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const urlRef = useRef<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const pendingUrlRef = useRef<string | null>(null);
+  const guardRef = useRef(false);
+
+  const setStatusSafe = useCallback((next: StoryAudioStatus) => {
+    statusRef.current = next;
+    setStatus(next);
+  }, []);
+
+  const releaseUrl = useCallback(() => {
+    if (urlRef.current) {
+      URL.revokeObjectURL(urlRef.current);
+      urlRef.current = null;
+    }
+  }, []);
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.currentTime = 0;
+      audioRef.current = null;
+    }
+    releaseUrl();
+    pendingUrlRef.current = null;
+    setStatusSafe('idle');
+    onIdle?.();
+  }, [releaseUrl, setStatusSafe, onIdle]);
+
+  useEffect(() => () => stop(), [stop]);
+
+  const playUrl = useCallback(
+    async (url: string): Promise<boolean> => {
+      releaseUrl();
+      urlRef.current = url;
+      const audio = new Audio(url);
+      audioRef.current = audio;
+      audio.onended = () => {
+        releaseUrl();
+        audioRef.current = null;
+        setStatusSafe('idle');
+        onIdle?.();
+      };
+
+      try {
+        await audio.play();
+        setStatusSafe('playing');
+        return true;
+      } catch {
+        pendingUrlRef.current = url;
+        audioRef.current = null;
+        setStatusSafe('idle');
+        return false;
+      }
+    },
+    [releaseUrl, setStatusSafe]
+  );
+
+  const toggle = useCallback(
+    async (loadBlob: (signal: AbortSignal) => Promise<Blob>) => {
+      unlockStoryAudio();
+
+      if (guardRef.current) return;
+      guardRef.current = true;
+      requestAnimationFrame(() => {
+        guardRef.current = false;
+      });
+
+      if (statusRef.current === 'playing' || statusRef.current === 'loading') {
+        stop();
+        return;
+      }
+
+      if (pendingUrlRef.current) {
+        const ok = await playUrl(pendingUrlRef.current);
+        pendingUrlRef.current = null;
+        if (!ok) onError?.('Tap Listen again to start playback.');
+        return;
+      }
+
+      setStatusSafe('loading');
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        const blob = await loadBlob(controller.signal);
+        if (controller.signal.aborted) {
+          setStatusSafe('idle');
+          return;
+        }
+
+        const url = URL.createObjectURL(blob);
+        const ok = await playUrl(url);
+        if (!ok) {
+          onError?.('Tap Listen again to start playback.');
+        }
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        onError?.('Could not play narration.');
+        setStatusSafe('idle');
+      } finally {
+        if (abortRef.current === controller) abortRef.current = null;
+      }
+    },
+    [onError, playUrl, setStatusSafe, stop]
+  );
+
+  const isActive = status === 'loading' || status === 'playing';
+
+  return {
+    status,
+    isActive,
+    isLoading: status === 'loading',
+    isPlaying: status === 'playing',
+    toggle,
+    stop,
+    unlock: unlockStoryAudio,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes story narration on Today plan and saved stories.

### Today plan Listen
- Shared `useStoryAudio` hook unlocks audio on pointer down (required for iOS)
- Guards against duplicate tap cancelling fetch before playback starts
- Stop works during loading and playback

### Saved stories
- Listen button shows **Stop** while loading and while playing (was disabled/hidden during load)
- Separate illustrating vs audio busy state so buttons do not conflict
- More → Stories opens the stories tab via `?tab=stories`

## Test plan
- [ ] Today → Read Story → Listen plays narration
- [ ] Tap Stop while loading or playing
- [ ] More → Stories → Listen shows Stop, tap again to stop
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a231d1e6-caff-4d6d-acd3-83f350fa4fb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a231d1e6-caff-4d6d-acd3-83f350fa4fb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

