### PR TITLE
Fix Today story Listen aborting on re-render

### DIFF
--- a/src/app/api/saved/stories/[id]/audio/route.ts
+++ b/src/app/api/saved/stories/[id]/audio/route.ts
@@ -4,6 +4,8 @@ import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/db";
 import { generateStoryNarration } from "@/lib/services/story-media";
 
+export const maxDuration = 60;
+
 export async function GET(
   _request: Request,
   { params }: { params: { id: string } }
@@ -33,7 +35,7 @@ export async function GET(
     });
   }
 
-  return new NextResponse(audioBuffer, {
+  return new NextResponse(new Uint8Array(audioBuffer), {
     headers: {
       "Content-Type": "audio/mpeg",
       "Cache-Control": "private, max-age=86400",

--- a/src/app/api/stories/narrate/route.ts
+++ b/src/app/api/stories/narrate/route.ts
@@ -4,6 +4,8 @@ import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/db";
 import { generateStoryNarration } from "@/lib/services/story-media";
 
+export const maxDuration = 60;
+
 export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
@@ -21,7 +23,7 @@ export async function POST(request: Request) {
       select: { audioData: true },
     });
     if (existing?.audioData) {
-      return new NextResponse(existing.audioData, {
+      return new NextResponse(new Uint8Array(existing.audioData), {
         headers: {
           "Content-Type": "audio/mpeg",
           "Cache-Control": "private, max-age=86400",
@@ -39,7 +41,7 @@ export async function POST(request: Request) {
     });
   }
 
-  return new NextResponse(audioBuffer, {
+  return new NextResponse(new Uint8Array(audioBuffer), {
     headers: {
       "Content-Type": "audio/mpeg",
       "Cache-Control": "private, max-age=3600",

--- a/src/app/saved/page.tsx
+++ b/src/app/saved/page.tsx
@@ -9,13 +9,14 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import {
-  ArrowLeft, ChefHat, BookOpen, Trash2, Volume2, Square,
+  ArrowLeft, ChefHat, BookOpen, Trash2,
   Loader2, ImageIcon, ChevronDown, ChevronUp
 } from 'lucide-react';
 import type { DailyBriefRecipe } from '@/types/daily-brief';
 import { format } from 'date-fns';
 import { toast } from 'sonner';
-import { unlockStoryAudio, useStoryAudio } from '@/hooks/use-story-audio';
+import { useStoryAudio } from '@/hooks/use-story-audio';
+import { StoryListenButton } from '@/components/story/story-listen-button';
 
 interface SavedRecipe {
   id: string;
@@ -319,27 +320,11 @@ function SavedPageContent() {
                         )}
                         {item.illustrationData ? 'New Art' : 'Illustrate'}
                       </Button>
-                      <Button
-                        size="sm"
-                        variant={isAudioActive ? 'default' : 'outline'}
-                        className="rounded-xl touch-target"
-                        type="button"
-                        onPointerDown={(e) => {
-                          e.stopPropagation();
-                          unlockStoryAudio();
-                        }}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          toggleStoryAudio(item);
-                        }}
-                      >
-                        {isAudioActive ? (
-                          <Square className="h-3.5 w-3.5 mr-1" />
-                        ) : (
-                          <Volume2 className="h-3.5 w-3.5 mr-1" />
-                        )}
-                        {isAudioActive ? 'Stop' : 'Listen'}
-                      </Button>
+                      <StoryListenButton
+                        active={isAudioActive}
+                        onToggle={() => toggleStoryAudio(item)}
+                        className="rounded-xl"
+                      />
                     </div>
                   </CardContent>
                 </Card>

--- a/src/components/story/story-listen-button.tsx
+++ b/src/components/story/story-listen-button.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { Square, Volume2 } from 'lucide-react';
+import { unlockStoryAudio } from '@/hooks/use-story-audio';
+import { cn } from '@/lib/utils';
+
+interface StoryListenButtonProps {
+  active: boolean;
+  onToggle: () => void;
+  className?: string;
+  size?: 'sm' | 'default';
+}
+
+/** Listen/Stop control with mobile-safe touch handling (avoids ghost double-tap). */
+export function StoryListenButton({ active, onToggle, className, size = 'sm' }: StoryListenButtonProps) {
+  const touchHandledRef = useRef(false);
+
+  const handleActivate = () => {
+    unlockStoryAudio();
+    onToggle();
+  };
+
+  return (
+    <Button
+      size={size}
+      variant={active ? 'default' : 'outline'}
+      type="button"
+      className={cn('touch-target', className)}
+      onTouchStart={(e) => {
+        e.stopPropagation();
+        touchHandledRef.current = true;
+        handleActivate();
+      }}
+      onClick={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        if (touchHandledRef.current) {
+          touchHandledRef.current = false;
+          return;
+        }
+        handleActivate();
+      }}
+    >
+      {active ? (
+        <Square className="h-3.5 w-3.5 mr-1" />
+      ) : (
+        <Volume2 className="h-3.5 w-3.5 mr-1" />
+      )}
+      {active ? 'Stop' : 'Listen'}
+    </Button>
+  );
+}

--- a/src/components/today/today-detail-views.tsx
+++ b/src/components/today/today-detail-views.tsx
@@ -3,7 +3,7 @@
 import { createContext, useContext, useState, useRef, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Bookmark, Volume2, Square, Loader2, ImageIcon } from 'lucide-react';
+import { Bookmark, Loader2, ImageIcon } from 'lucide-react';
 import type {
   DailyBriefRecipe,
   DailyBriefPlay,
@@ -11,7 +11,8 @@ import type {
   DailyBriefDevelopment,
 } from '@/types/daily-brief';
 import { toast } from 'sonner';
-import { unlockStoryAudio, useStoryAudio } from '@/hooks/use-story-audio';
+import { useStoryAudio } from '@/hooks/use-story-audio';
+import { StoryListenButton } from '@/components/story/story-listen-button';
 
 type DetailPart = 'content' | 'footer';
 
@@ -237,11 +238,22 @@ function useStoryDetailMedia(story: DailyBriefStory) {
     setIllustrationData(normalizeIllustrationSrc(story.illustrationData));
   }, [story.illustrationData]);
 
+  const storyKeyRef = useRef(`${story.title}|${story.story}`);
+  const stopAudioRef = useRef(storyAudio.stop);
+  stopAudioRef.current = storyAudio.stop;
+
   useEffect(() => {
-    storyAudio.stop();
-  }, [story.title, story.story]); // eslint-disable-line react-hooks/exhaustive-deps
+    const key = `${story.title}|${story.story}`;
+    if (storyKeyRef.current === key) return;
+    storyKeyRef.current = key;
+    stopAudioRef.current();
+  }, [story.title, story.story]);
 
   const handleNarrate = () => {
+    if (!story.story?.trim()) {
+      toast.error('Story text is missing.');
+      return;
+    }
     void storyAudio.toggle(async (signal) => {
       const res = await fetch('/api/stories/narrate', {
         method: 'POST',
@@ -249,8 +261,13 @@ function useStoryDetailMedia(story: DailyBriefStory) {
         body: JSON.stringify({ story: story.story, cache: false }),
         signal,
       });
-      if (!res.ok) throw new Error('Narration failed');
-      return res.blob();
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(typeof err.error === 'string' ? err.error : 'Narration failed');
+      }
+      const blob = await res.blob();
+      if (!blob.size) throw new Error('Empty audio response');
+      return blob;
     });
   };
 
@@ -286,7 +303,6 @@ function useStoryDetailMedia(story: DailyBriefStory) {
     handleNarrate,
     handleIllustrate,
     stopAudio: storyAudio.stop,
-    unlockAudio: unlockStoryAudio,
   };
 }
 
@@ -333,7 +349,6 @@ export function StoryDetailFooter() {
     handleNarrate,
     handleIllustrate,
     stopAudio,
-    unlockAudio,
   } = useStoryDetailContext();
   const mediaActive = isNarrating;
 
@@ -367,27 +382,11 @@ export function StoryDetailFooter() {
             )}
             Cover art
           </Button>
-          <Button
-            size="sm"
-            variant={mediaActive ? 'default' : 'outline'}
-            className="rounded-full touch-target"
-            type="button"
-            onPointerDown={(e) => {
-              e.stopPropagation();
-              unlockAudio();
-            }}
-            onClick={(e) => {
-              e.stopPropagation();
-              handleNarrate();
-            }}
-          >
-            {mediaActive ? (
-              <Square className="h-3.5 w-3.5 mr-1" />
-            ) : (
-              <Volume2 className="h-3.5 w-3.5 mr-1" />
-            )}
-            {mediaActive ? 'Stop' : 'Listen'}
-          </Button>
+          <StoryListenButton
+            active={mediaActive}
+            onToggle={handleNarrate}
+            className="rounded-full"
+          />
         </div>
       </div>
       <div className="flex gap-2">

--- a/src/hooks/use-story-audio.ts
+++ b/src/hooks/use-story-audio.ts
@@ -4,35 +4,72 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 export type StoryAudioStatus = 'idle' | 'loading' | 'playing';
 
-let sharedAudioContext: AudioContext | null = null;
-
-/** Resume audio context synchronously inside a user gesture (required on iOS). */
-export function unlockStoryAudio() {
-  if (typeof window === 'undefined') return;
-  try {
-    sharedAudioContext ??= new AudioContext();
-    if (sharedAudioContext.state === 'suspended') {
-      void sharedAudioContext.resume();
-    }
-  } catch {
-    // Ignore — HTMLAudio fallback may still work.
-  }
-}
+/** Minimal silent MP3 used to unlock mobile audio playback. */
+const SILENT_MP3 =
+  'data:audio/mp3;base64,SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjU4LjI5LjEwMAAAAAAAAAAAAAAA//tQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWGluZwAAAA8AAAACAAABhgC7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7//////////////////////////////////////////////////////////////////8AAAAATGF2YzU4LjQ5AAAAAAAAAAAAAAAAJAAAAAAAAAAAAYYNbtV0AAAAAAAAAAAAAAAAAAAAAP/+1DEAAAGAAGn9AAAIAAANIAAAAQAAAGkAAAAIAAANIAAAARMQU1FMy4xMDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA//tQxAAACAAAGkAAAAIAAANIAAAAQAAAaQAAAAgAAA0gAAABExBTUUzLjEwMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP/7UMQAAAIAAGf9AAACAAADSAAAAEAAABpAAAACAAADSAAAAA=';
 
 interface UseStoryAudioOptions {
   onError?: (message: string) => void;
   onIdle?: () => void;
 }
 
+export function unlockStoryAudio() {
+  if (typeof window === 'undefined') return;
+  try {
+    const ctx = getOrCreateAudioContext();
+    if (ctx.state === 'suspended') {
+      void ctx.resume();
+    }
+    primeHtmlAudio();
+  } catch {
+    // Ignore — playback may still work on desktop.
+  }
+}
+
+function getOrCreateAudioContext(): AudioContext {
+  const w = window as Window & {
+    AudioContext?: typeof AudioContext;
+    webkitAudioContext?: typeof AudioContext;
+  };
+  const Ctx = w.AudioContext ?? w.webkitAudioContext;
+  if (!Ctx) throw new Error('AudioContext unavailable');
+  if (!sharedAudioContext || sharedAudioContext.state === 'closed') {
+    sharedAudioContext = new Ctx();
+  }
+  return sharedAudioContext as AudioContext;
+}
+
+let sharedAudioContext: AudioContext | null = null;
+let primedAudio: HTMLAudioElement | null = null;
+
+function primeHtmlAudio() {
+  if (primedAudio) return;
+  const audio = new Audio(SILENT_MP3);
+  audio.volume = 0.01;
+  audio.preload = 'auto';
+  primedAudio = audio;
+  void audio.play().then(() => {
+    audio.pause();
+    audio.currentTime = 0;
+  }).catch(() => {
+    // Expected on some browsers until a later user gesture.
+  });
+}
+
 export function useStoryAudio(options: UseStoryAudioOptions = {}) {
-  const { onError, onIdle } = options;
+  const onErrorRef = useRef(options.onError);
+  const onIdleRef = useRef(options.onIdle);
+  onErrorRef.current = options.onError;
+  onIdleRef.current = options.onIdle;
+
   const [status, setStatus] = useState<StoryAudioStatus>('idle');
   const statusRef = useRef<StoryAudioStatus>('idle');
-  const audioRef = useRef<HTMLAudioElement | null>(null);
-  const urlRef = useRef<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
-  const pendingUrlRef = useRef<string | null>(null);
-  const guardRef = useRef(false);
+  const sourceRef = useRef<AudioBufferSourceNode | null>(null);
+  const htmlAudioRef = useRef<HTMLAudioElement | null>(null);
+  const urlRef = useRef<string | null>(null);
+  const loadStartedAtRef = useRef(0);
+  const sessionRef = useRef(0);
 
   const setStatusSafe = useCallback((next: StoryAudioStatus) => {
     statusRef.current = next;
@@ -47,41 +84,94 @@ export function useStoryAudio(options: UseStoryAudioOptions = {}) {
   }, []);
 
   const stop = useCallback(() => {
+    sessionRef.current += 1;
     abortRef.current?.abort();
     abortRef.current = null;
-    if (audioRef.current) {
-      audioRef.current.pause();
-      audioRef.current.currentTime = 0;
-      audioRef.current = null;
+
+    if (sourceRef.current) {
+      try {
+        sourceRef.current.stop();
+      } catch {
+        // Already stopped.
+      }
+      sourceRef.current = null;
     }
+
+    if (htmlAudioRef.current) {
+      htmlAudioRef.current.pause();
+      htmlAudioRef.current.currentTime = 0;
+    }
+
     releaseUrl();
-    pendingUrlRef.current = null;
     setStatusSafe('idle');
-    onIdle?.();
-  }, [releaseUrl, setStatusSafe, onIdle]);
+    onIdleRef.current?.();
+  }, [releaseUrl, setStatusSafe]);
 
   useEffect(() => () => stop(), [stop]);
 
-  const playUrl = useCallback(
-    async (url: string): Promise<boolean> => {
+  const playBlob = useCallback(
+    async (blob: Blob, session: number): Promise<boolean> => {
+      if (session !== sessionRef.current) return false;
+
+      if (!blob.size) {
+        onErrorRef.current?.('No audio received.');
+        return false;
+      }
+
+      unlockStoryAudio();
+      const arrayBuffer = await blob.arrayBuffer();
+      if (session !== sessionRef.current) return false;
+
+      // Prefer Web Audio — works after async fetch once context was unlocked on tap.
+      try {
+        const ctx = getOrCreateAudioContext();
+        if (ctx.state === 'suspended') {
+          await ctx.resume();
+        }
+        const audioBuffer = await ctx.decodeAudioData(arrayBuffer.slice(0));
+        if (session !== sessionRef.current) return false;
+
+        const source = ctx.createBufferSource();
+        source.buffer = audioBuffer;
+        source.connect(ctx.destination);
+        source.onended = () => {
+          if (session !== sessionRef.current) return;
+          sourceRef.current = null;
+          setStatusSafe('idle');
+          onIdleRef.current?.();
+        };
+        sourceRef.current = source;
+        source.start(0);
+        setStatusSafe('playing');
+        return true;
+      } catch {
+        // Fall back to HTMLAudio below.
+      }
+
       releaseUrl();
+      const url = URL.createObjectURL(new Blob([arrayBuffer], { type: 'audio/mpeg' }));
       urlRef.current = url;
-      const audio = new Audio(url);
-      audioRef.current = audio;
+
+      const audio = htmlAudioRef.current ?? new Audio();
+      htmlAudioRef.current = audio;
+      audio.src = url;
       audio.onended = () => {
+        if (session !== sessionRef.current) return;
         releaseUrl();
-        audioRef.current = null;
         setStatusSafe('idle');
-        onIdle?.();
+        onIdleRef.current?.();
       };
 
       try {
         await audio.play();
+        if (session !== sessionRef.current) {
+          audio.pause();
+          return false;
+        }
         setStatusSafe('playing');
         return true;
       } catch {
-        pendingUrlRef.current = url;
-        audioRef.current = null;
+        onErrorRef.current?.('Tap Listen again to start playback.');
         setStatusSafe('idle');
         return false;
       }
@@ -93,49 +183,47 @@ export function useStoryAudio(options: UseStoryAudioOptions = {}) {
     async (loadBlob: (signal: AbortSignal) => Promise<Blob>) => {
       unlockStoryAudio();
 
-      if (guardRef.current) return;
-      guardRef.current = true;
-      requestAnimationFrame(() => {
-        guardRef.current = false;
-      });
-
-      if (statusRef.current === 'playing' || statusRef.current === 'loading') {
+      if (statusRef.current === 'playing') {
         stop();
         return;
       }
 
-      if (pendingUrlRef.current) {
-        const ok = await playUrl(pendingUrlRef.current);
-        pendingUrlRef.current = null;
-        if (!ok) onError?.('Tap Listen again to start playback.');
+      if (statusRef.current === 'loading') {
+        // Ignore ghost duplicate taps right after starting.
+        if (Date.now() - loadStartedAtRef.current < 700) return;
+        stop();
         return;
       }
 
+      const session = sessionRef.current + 1;
+      sessionRef.current = session;
+      loadStartedAtRef.current = Date.now();
       setStatusSafe('loading');
+
       const controller = new AbortController();
       abortRef.current = controller;
 
       try {
         const blob = await loadBlob(controller.signal);
-        if (controller.signal.aborted) {
+        if (controller.signal.aborted || session !== sessionRef.current) {
           setStatusSafe('idle');
           return;
         }
 
-        const url = URL.createObjectURL(blob);
-        const ok = await playUrl(url);
-        if (!ok) {
-          onError?.('Tap Listen again to start playback.');
-        }
+        await playBlob(blob, session);
       } catch (err) {
-        if (err instanceof DOMException && err.name === 'AbortError') return;
-        onError?.('Could not play narration.');
+        if (session !== sessionRef.current) return;
+        if (err instanceof DOMException && err.name === 'AbortError') {
+          setStatusSafe('idle');
+          return;
+        }
+        onErrorRef.current?.('Could not play narration.');
         setStatusSafe('idle');
       } finally {
         if (abortRef.current === controller) abortRef.current = null;
       }
     },
-    [onError, playUrl, setStatusSafe, stop]
+    [playBlob, setStatusSafe, stop]
   );
 
   const isActive = status === 'loading' || status === 'playing';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause

Listen on Today was **starting then immediately stopping** because a `useEffect` depended on the entire `storyAudio` object. Every re-render (including when status changed to `loading`) re-ran the effect and called `stop()`, aborting the narration fetch.

## Fixes

- Only stop audio when the story text actually changes (stable effect deps)
- Rewrite playback with **Web Audio API** after unlocking context on touch
- Add `StoryListenButton` with touch/click deduplication for mobile
- Narrate + saved audio routes: `Uint8Array` body + `maxDuration = 60`

## Test plan
- [ ] Today → Read Story → Listen plays full narration
- [ ] Tap Stop while loading or playing
- [ ] Saved stories Listen/Stop works
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a231d1e6-caff-4d6d-acd3-83f350fa4fb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a231d1e6-caff-4d6d-acd3-83f350fa4fb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

