### PR TITLE
Cache and prefetch story narration for faster Listen

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -271,13 +271,15 @@ model WeeklyReflection {
 }
 
 model DailyBrief {
-  id        String   @id @default(cuid())
-  userId    String
-  date      DateTime @db.Date
-  content   Json
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id              String   @id @default(cuid())
+  userId          String
+  date            DateTime @db.Date
+  content         Json
+  storyAudioData  Bytes?
+  storyAudioHash  String?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, date])
   @@index([userId])

--- a/src/app/api/daily-brief/route.ts
+++ b/src/app/api/daily-brief/route.ts
@@ -8,6 +8,7 @@ import {
   getHomeSupplementaryData,
   generateAndSaveBriefIllustrations,
   needsBriefIllustrations,
+  warmTodayStoryAudio,
 } from "@/lib/services/daily-brief";
 import type { DailyBriefContent } from "@/types/daily-brief";
 import type { IllustrationSection } from "@/lib/services/card-illustrations";
@@ -85,6 +86,7 @@ export async function PATCH(request: Request) {
 
     if (action === "regenerate-story") {
       const brief = await regenerateDailyBriefSection(session.user.id, "story");
+      warmTodayStoryAudio(session.user.id);
       return NextResponse.json({ brief });
     }
 

--- a/src/app/api/stories/narrate/route.ts
+++ b/src/app/api/stories/narrate/route.ts
@@ -3,6 +3,12 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/db";
 import { generateStoryNarration } from "@/lib/services/story-media";
+import {
+  getCachedTodayStoryAudio,
+  saveTodayStoryAudio,
+  hashStoryText,
+  getTodayBriefStory,
+} from "@/lib/services/story-audio-cache";
 
 export const maxDuration = 60;
 
@@ -12,9 +18,26 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { story, savedStoryId, cache } = await request.json();
+  const { story, savedStoryId, cache, source } = await request.json();
   if (!story?.trim()) {
     return NextResponse.json({ error: "Story text is required" }, { status: 400 });
+  }
+
+  const trimmed = story.trim();
+
+  if (source === "today" || cache !== false) {
+    const todayStory = await getTodayBriefStory(session.user.id);
+    if (todayStory && hashStoryText(todayStory) === hashStoryText(trimmed)) {
+      const cached = await getCachedTodayStoryAudio(session.user.id, trimmed);
+      if (cached) {
+        return new NextResponse(new Uint8Array(cached), {
+          headers: {
+            "Content-Type": "audio/mpeg",
+            "Cache-Control": "private, max-age=86400",
+          },
+        });
+      }
+    }
   }
 
   if (savedStoryId) {
@@ -32,7 +55,12 @@ export async function POST(request: Request) {
     }
   }
 
-  const audioBuffer = await generateStoryNarration(story.trim());
+  const audioBuffer = await generateStoryNarration(trimmed);
+
+  const todayStory = await getTodayBriefStory(session.user.id);
+  if (todayStory && hashStoryText(todayStory) === hashStoryText(trimmed)) {
+    await saveTodayStoryAudio(session.user.id, trimmed, audioBuffer);
+  }
 
   if (savedStoryId && cache !== false) {
     await prisma.savedStory.updateMany({

--- a/src/app/api/stories/narrate/today/route.ts
+++ b/src/app/api/stories/narrate/today/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { getOrGenerateTodayStoryAudio } from "@/lib/services/story-audio-cache";
+
+export const maxDuration = 60;
+
+/** Cached narration for today's brief story — instant on repeat listens. */
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const audioBuffer = await getOrGenerateTodayStoryAudio(session.user.id);
+    return new NextResponse(new Uint8Array(audioBuffer), {
+      headers: {
+        "Content-Type": "audio/mpeg",
+        "Cache-Control": "private, max-age=86400",
+      },
+    });
+  } catch (error) {
+    console.error("Today story audio GET error:", error);
+    const message = error instanceof Error ? error.message : "Narration failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+/** Prefetch/warm cache without waiting for the client to tap Listen. */
+export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    await getOrGenerateTodayStoryAudio(session.user.id);
+    return NextResponse.json({ ok: true, cached: true });
+  } catch (error) {
+    console.error("Today story audio warm error:", error);
+    const message = error instanceof Error ? error.message : "Warm failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -25,6 +25,7 @@ import { buildFocusCards, truncateWords } from '@/lib/today-focus';
 import { trackEvent, trackReturnVisit } from '@/lib/analytics';
 import { format } from 'date-fns';
 import { toast } from 'sonner';
+import { prefetchTodayStoryAudio, invalidateTodayStoryAudioCache } from '@/lib/story-audio-prefetch';
 
 async function parseApiJson<T>(response: Response): Promise<T> {
   const text = await response.text();
@@ -116,6 +117,13 @@ export default function TodayPage() {
     loadToday().finally(() => setLoading(false));
   }, [status, router, loadToday]);
 
+  useEffect(() => {
+    if (!data?.brief?.bedtimeStory?.story) return;
+    prefetchTodayStoryAudio().catch(() => {
+      // Warm happens in background; Listen will retry if this fails.
+    });
+  }, [data?.brief?.bedtimeStory?.story]);
+
   const patchBrief = async (action: string, extra?: Record<string, unknown>) => {
     const res = await fetch('/api/daily-brief', {
       method: 'PATCH',
@@ -140,6 +148,10 @@ export default function TodayPage() {
     setRotating(section);
     try {
       await patchBrief(actionMap[section]);
+      if (section === 'story') {
+        invalidateTodayStoryAudioCache();
+        prefetchTodayStoryAudio().catch(() => {});
+      }
       toast.success('Here\'s another idea!');
     } catch {
       toast.error('Could not rotate suggestion.');

--- a/src/components/home/story-card.tsx
+++ b/src/components/home/story-card.tsx
@@ -71,7 +71,7 @@ export function StoryCard({ story, onSave, imagesLoading }: StoryCardProps) {
       const res = await fetch('/api/stories/narrate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ story: story.story, cache: false }),
+        body: JSON.stringify({ story: story.story, cache: true, source: 'today' }),
       });
       if (!res.ok) throw new Error();
       const blob = await res.blob();

--- a/src/components/today/today-detail-views.tsx
+++ b/src/components/today/today-detail-views.tsx
@@ -12,6 +12,7 @@ import type {
 } from '@/types/daily-brief';
 import { toast } from 'sonner';
 import { useStoryAudio } from '@/hooks/use-story-audio';
+import { getTodayStoryAudioFetch } from '@/lib/story-audio-prefetch';
 import { StoryListenButton } from '@/components/story/story-listen-button';
 
 type DetailPart = 'content' | 'footer';
@@ -254,21 +255,7 @@ function useStoryDetailMedia(story: DailyBriefStory) {
       toast.error('Story text is missing.');
       return;
     }
-    void storyAudio.toggle(async (signal) => {
-      const res = await fetch('/api/stories/narrate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ story: story.story, cache: false }),
-        signal,
-      });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        throw new Error(typeof err.error === 'string' ? err.error : 'Narration failed');
-      }
-      const blob = await res.blob();
-      if (!blob.size) throw new Error('Empty audio response');
-      return blob;
-    });
+    void storyAudio.toggle(async (signal) => getTodayStoryAudioFetch(signal));
   };
 
   const handleIllustrate = async () => {

--- a/src/lib/services/daily-brief.ts
+++ b/src/lib/services/daily-brief.ts
@@ -5,8 +5,10 @@ import { toDateKey, yesterdayDateKey } from "@/lib/date-utils";
 import type { DailyBriefContent, DailyBriefPlay, DailyBriefRecipe, DailyBriefStory, DailyBriefDevelopment } from "@/types/daily-brief";
 import { enrichBriefWithIllustrations, needsBriefIllustrations, type IllustrationSection } from "@/lib/services/card-illustrations";
 import type { BriefProfile } from "@/lib/daily-brief-context";
+import { clearTodayStoryAudio, warmTodayStoryAudio } from "@/lib/services/story-audio-cache";
 
 export { needsBriefIllustrations };
+export { warmTodayStoryAudio };
 
 export async function generateAndSaveBriefIllustrations(
   userId: string,
@@ -131,6 +133,7 @@ export async function getOrCreateDailyBrief(userId: string): Promise<DailyBriefC
     await prisma.dailyBrief.create({
       data: { userId, date: today, content: content as object },
     });
+    warmTodayStoryAudio(userId);
   } catch (error) {
     console.error("Failed to persist daily brief:", error);
   }
@@ -162,6 +165,7 @@ export async function updateDailyBriefSection(
   if (section === "story") {
     content.bedtimeStory = value as DailyBriefStory;
     delete content.bedtimeStory.illustrationData;
+    await clearTodayStoryAudio(userId);
   }
   if (section === "language") {
     const lang = value as DailyBriefDevelopment;

--- a/src/lib/services/story-audio-cache.ts
+++ b/src/lib/services/story-audio-cache.ts
@@ -1,0 +1,91 @@
+import { createHash } from "crypto";
+import { prisma } from "@/lib/db";
+import { toDateKey } from "@/lib/date-utils";
+import { generateStoryNarration } from "@/lib/services/story-media";
+import type { DailyBriefContent } from "@/types/daily-brief";
+
+export function hashStoryText(text: string): string {
+  return createHash("sha256").update(text.trim()).digest("hex");
+}
+
+export async function getTodayBriefStory(userId: string): Promise<string | null> {
+  const brief = await prisma.dailyBrief.findUnique({
+    where: { userId_date: { userId, date: toDateKey() } },
+    select: { content: true },
+  });
+  if (!brief) return null;
+  const content = brief.content as unknown as DailyBriefContent;
+  return content.bedtimeStory?.story?.trim() || null;
+}
+
+export async function getCachedTodayStoryAudio(
+  userId: string,
+  storyText: string
+): Promise<Buffer | null> {
+  const hash = hashStoryText(storyText);
+  const brief = await prisma.dailyBrief.findUnique({
+    where: { userId_date: { userId, date: toDateKey() } },
+    select: { storyAudioData: true, storyAudioHash: true },
+  });
+  if (brief?.storyAudioData && brief.storyAudioHash === hash) {
+    return Buffer.from(brief.storyAudioData);
+  }
+  return null;
+}
+
+export async function saveTodayStoryAudio(
+  userId: string,
+  storyText: string,
+  audio: Buffer
+): Promise<void> {
+  const hash = hashStoryText(storyText);
+  await prisma.dailyBrief.update({
+    where: { userId_date: { userId, date: toDateKey() } },
+    data: { storyAudioData: audio, storyAudioHash: hash },
+  });
+}
+
+export async function clearTodayStoryAudio(userId: string): Promise<void> {
+  await prisma.dailyBrief.updateMany({
+    where: { userId, date: toDateKey() },
+    data: { storyAudioData: null, storyAudioHash: null },
+  });
+}
+
+const inflight = new Map<string, Promise<Buffer>>();
+
+export async function getOrGenerateTodayStoryAudio(userId: string): Promise<Buffer> {
+  const storyText = await getTodayBriefStory(userId);
+  if (!storyText) {
+    throw new Error("Today's story not found");
+  }
+
+  const cached = await getCachedTodayStoryAudio(userId, storyText);
+  if (cached) return cached;
+
+  const key = `${userId}:${hashStoryText(storyText)}`;
+  const pending = inflight.get(key);
+  if (pending) return pending;
+
+  const task = (async () => {
+    const again = await getCachedTodayStoryAudio(userId, storyText);
+    if (again) return again;
+
+    const audio = await generateStoryNarration(storyText);
+    await saveTodayStoryAudio(userId, storyText, audio);
+    return audio;
+  })();
+
+  inflight.set(key, task);
+  try {
+    return await task;
+  } finally {
+    inflight.delete(key);
+  }
+}
+
+export function warmTodayStoryAudio(userId: string): void {
+  void getOrGenerateTodayStoryAudio(userId).catch((err) => {
+    console.warn("Story audio warm failed:", err);
+  });
+}

--- a/src/lib/story-audio-prefetch.ts
+++ b/src/lib/story-audio-prefetch.ts
@@ -1,0 +1,56 @@
+'use client';
+
+const blobCache = new Map<string, Blob>();
+let todayPrefetch: Promise<Blob> | null = null;
+
+export function cacheStoryBlob(key: string, blob: Blob) {
+  blobCache.set(key, blob);
+}
+
+export function getCachedStoryBlob(key: string): Blob | undefined {
+  return blobCache.get(key);
+}
+
+/** Start generating today's narration in the background while the user browses Today. */
+export function prefetchTodayStoryAudio() {
+  if (todayPrefetch) return todayPrefetch;
+
+  todayPrefetch = fetch('/api/stories/narrate/today')
+    .then(async (res) => {
+      if (!res.ok) throw new Error('Prefetch failed');
+      const blob = await res.blob();
+      if (!blob.size) throw new Error('Empty audio');
+      cacheStoryBlob('today', blob);
+      return blob;
+    })
+    .catch((err) => {
+      todayPrefetch = null;
+      throw err;
+    });
+
+  return todayPrefetch;
+}
+
+export function getTodayStoryAudioFetch(signal?: AbortSignal): Promise<Blob> {
+  const cached = getCachedStoryBlob('today');
+  if (cached) return Promise.resolve(cached);
+
+  if (todayPrefetch && !signal) {
+    return todayPrefetch;
+  }
+
+  return fetch('/api/stories/narrate/today', { signal })
+    .then(async (res) => {
+      if (!res.ok) throw new Error('Narration failed');
+      const blob = await res.blob();
+      if (!blob.size) throw new Error('Empty audio');
+      cacheStoryBlob('today', blob);
+      todayPrefetch = Promise.resolve(blob);
+      return blob;
+    });
+}
+
+export function invalidateTodayStoryAudioCache() {
+  blobCache.delete('today');
+  todayPrefetch = null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Listen on Today was calling OpenAI TTS with `cache: false` every time, taking ~60s per tap.

## Solution

### Server cache
- Store today's narration MP3 on `DailyBrief` (`storyAudioData` + hash)
- Clear cache when story is rotated
- New `GET /api/stories/narrate/today` returns cached audio instantly on repeat listens

### Prefetch
- When Today loads, start generating narration in the background
- After "Try another" on story, invalidate client cache and prefetch the new story
- Warm server cache after brief creation and story regeneration

### Client cache
- In-memory blob cache for same-session replay without another network call

## Expected UX
- **First listen same day:** may still take ~30–60s if prefetch hasn't finished, but often faster because prefetch starts on page load
- **Second listen same day:** near-instant from DB cache
- **Same session replay:** instant from client cache

## Test plan
- [ ] Open Today — wait a few seconds — Read Story → Listen (should be faster than before)
- [ ] Listen again — should start almost immediately
- [ ] Try another story — first listen may take time, second should be fast
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a231d1e6-caff-4d6d-acd3-83f350fa4fb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a231d1e6-caff-4d6d-acd3-83f350fa4fb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

