### PR TITLE
Speed up Today page load and cache story cover art

### DIFF
--- a/src/app/api/daily-brief/route.ts
+++ b/src/app/api/daily-brief/route.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/services/daily-brief";
 import type { DailyBriefContent } from "@/types/daily-brief";
 import type { IllustrationSection } from "@/lib/services/card-illustrations";
+import { warmTodayStoryIllustration } from "@/lib/services/today-page";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -87,6 +88,7 @@ export async function PATCH(request: Request) {
     if (action === "regenerate-story") {
       const brief = await regenerateDailyBriefSection(session.user.id, "story");
       warmTodayStoryAudio(session.user.id);
+      warmTodayStoryIllustration(session.user.id);
       return NextResponse.json({ brief });
     }
 

--- a/src/app/api/stories/illustrate/route.ts
+++ b/src/app/api/stories/illustrate/route.ts
@@ -25,7 +25,8 @@ export async function POST(request: Request) {
       title.trim(),
       story.trim(),
       user?.childNickname,
-      moral?.trim() || null
+      moral?.trim() || null,
+      true
     );
 
     if (savedStoryId) {

--- a/src/app/api/stories/illustrate/today/route.ts
+++ b/src/app/api/stories/illustrate/today/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import {
+  getCachedTodayStoryIllustration,
+  getOrGenerateTodayStoryIllustration,
+} from "@/lib/services/today-page";
+
+export const maxDuration = 60;
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const illustrationData = await getCachedTodayStoryIllustration(session.user.id);
+  if (!illustrationData) {
+    return NextResponse.json({ error: "Not generated yet" }, { status: 404 });
+  }
+
+  return NextResponse.json({ illustrationData });
+}
+
+export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const illustrationData = await getOrGenerateTodayStoryIllustration(session.user.id);
+    return NextResponse.json({ illustrationData });
+  } catch (error) {
+    console.error("Today story illustration error:", error);
+    const message = error instanceof Error ? error.message : "Illustration failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/today/route.ts
+++ b/src/app/api/today/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { getTodayPageData } from "@/lib/services/today-page";
+import { warmTodayStoryAudio } from "@/lib/services/story-audio-cache";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+/** Fast Today dashboard payload — brief + profile only. */
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { brief, profile } = await getTodayPageData(session.user.id);
+    warmTodayStoryAudio(session.user.id);
+    return NextResponse.json({ brief, profile });
+  } catch (error) {
+    console.error("Today GET error:", error);
+    const message = error instanceof Error ? error.message : "Failed to load today";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -26,6 +26,11 @@ import { trackEvent, trackReturnVisit } from '@/lib/analytics';
 import { format } from 'date-fns';
 import { toast } from 'sonner';
 import { prefetchTodayStoryAudio, invalidateTodayStoryAudioCache } from '@/lib/story-audio-prefetch';
+import {
+  prefetchTodayStoryIllustration,
+  warmTodayStoryIllustration,
+  invalidateTodayStoryIllustrationCache,
+} from '@/lib/story-illustration-prefetch';
 
 async function parseApiJson<T>(response: Response): Promise<T> {
   const text = await response.text();
@@ -73,7 +78,7 @@ export default function TodayPage() {
 
   const loadToday = useCallback(() => {
     return Promise.all([
-      fetch('/api/daily-brief', { cache: 'no-store' }).then(async (r) => {
+      fetch('/api/today', { cache: 'no-store' }).then(async (r) => {
         const json = await parseApiJson<{ brief: DailyBriefContent; profile: TodayData['profile']; error?: string }>(r);
         if (!r.ok) throw new Error(json.error || `Failed (${r.status})`);
         return json;
@@ -119,10 +124,14 @@ export default function TodayPage() {
 
   useEffect(() => {
     if (!data?.brief?.bedtimeStory?.story) return;
-    prefetchTodayStoryAudio().catch(() => {
-      // Warm happens in background; Listen will retry if this fails.
-    });
+    prefetchTodayStoryAudio().catch(() => {});
+    prefetchTodayStoryIllustration().catch(() => {});
   }, [data?.brief?.bedtimeStory?.story]);
+
+  useEffect(() => {
+    if (activeDetail !== 'story' || !data?.brief?.bedtimeStory?.story) return;
+    warmTodayStoryIllustration().catch(() => {});
+  }, [activeDetail, data?.brief?.bedtimeStory?.story]);
 
   const patchBrief = async (action: string, extra?: Record<string, unknown>) => {
     const res = await fetch('/api/daily-brief', {
@@ -150,7 +159,10 @@ export default function TodayPage() {
       await patchBrief(actionMap[section]);
       if (section === 'story') {
         invalidateTodayStoryAudioCache();
+        invalidateTodayStoryIllustrationCache();
         prefetchTodayStoryAudio().catch(() => {});
+        prefetchTodayStoryIllustration().catch(() => {});
+        warmTodayStoryIllustration().catch(() => {});
       }
       toast.success('Here\'s another idea!');
     } catch {

--- a/src/components/today/today-detail-views.tsx
+++ b/src/components/today/today-detail-views.tsx
@@ -13,6 +13,7 @@ import type {
 import { toast } from 'sonner';
 import { useStoryAudio } from '@/hooks/use-story-audio';
 import { getTodayStoryAudioFetch } from '@/lib/story-audio-prefetch';
+import { fetchTodayStoryIllustration, prefetchTodayStoryIllustration, warmTodayStoryIllustration } from '@/lib/story-illustration-prefetch';
 import { StoryListenButton } from '@/components/story/story-listen-button';
 
 type DetailPart = 'content' | 'footer';
@@ -239,6 +240,16 @@ function useStoryDetailMedia(story: DailyBriefStory) {
     setIllustrationData(normalizeIllustrationSrc(story.illustrationData));
   }, [story.illustrationData]);
 
+  useEffect(() => {
+    if (story.illustrationData) return;
+    void prefetchTodayStoryIllustration().then((data) => {
+      if (data) setIllustrationData(normalizeIllustrationSrc(data));
+    });
+    void warmTodayStoryIllustration().then((data) => {
+      if (data) setIllustrationData(normalizeIllustrationSrc(data));
+    }).catch(() => {});
+  }, [story.title, story.story, story.illustrationData]);
+
   const storyKeyRef = useRef(`${story.title}|${story.story}`);
   const stopAudioRef = useRef(storyAudio.stop);
   stopAudioRef.current = storyAudio.stop;
@@ -261,15 +272,8 @@ function useStoryDetailMedia(story: DailyBriefStory) {
   const handleIllustrate = async () => {
     setIllustrating(true);
     try {
-      const res = await fetch('/api/stories/illustrate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: story.title, story: story.story, moral: story.moral }),
-      });
-      if (!res.ok) throw new Error();
-      const { illustrationData: data } = await res.json();
-      const normalized = normalizeIllustrationSrc(data);
-      setIllustrationData(normalized);
+      const data = await fetchTodayStoryIllustration();
+      setIllustrationData(normalizeIllustrationSrc(data));
       toast.success('Cover ready!');
       requestAnimationFrame(() => {
         coverRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });

--- a/src/lib/services/card-illustrations.ts
+++ b/src/lib/services/card-illustrations.ts
@@ -12,9 +12,12 @@ const ALL_SECTIONS: IllustrationSection[] = ["recipe", "play", "story", "develop
 
 export type { IllustrationSection };
 
-export async function generateCardIllustration(sceneDescription: string): Promise<string> {
+export async function generateCardIllustration(
+  sceneDescription: string,
+  fast = false
+): Promise<string> {
   const prompt = `${ILLUSTRATION_STYLE}. ${sceneDescription}`;
-  return generateOpenAIImage(prompt);
+  return generateOpenAIImage(prompt, { fast });
 }
 
 function sectionNeedsImage(brief: DailyBriefContent, section: IllustrationSection): boolean {

--- a/src/lib/services/openai-image.ts
+++ b/src/lib/services/openai-image.ts
@@ -27,8 +27,13 @@ function buildModelList(): string[] {
   return [preferred, ...defaults.filter((m) => m !== preferred)];
 }
 
-export async function generateOpenAIImage(prompt: string): Promise<string> {
-  const models = buildModelList();
+export async function generateOpenAIImage(
+  prompt: string,
+  options?: { fast?: boolean }
+): Promise<string> {
+  const models = options?.fast
+    ? ["gpt-image-1-mini", "gpt-image-1", "dall-e-2", "dall-e-3"]
+    : buildModelList();
   let lastError: unknown;
 
   for (const model of models) {
@@ -38,7 +43,10 @@ export async function generateOpenAIImage(prompt: string): Promise<string> {
         prompt,
         size: "1024x1024",
         ...(isGptImageModel(model)
-          ? { quality: "medium" as const, output_format: "png" as const }
+          ? {
+              quality: (options?.fast ? "low" : "medium") as "low" | "medium",
+              output_format: "png" as const,
+            }
           : model === "dall-e-3"
             ? { quality: "standard" as const }
             : {}),

--- a/src/lib/services/story-media.ts
+++ b/src/lib/services/story-media.ts
@@ -10,13 +10,14 @@ export async function generateStoryIllustration(
   title: string,
   storyExcerpt: string,
   childName?: string | null,
-  moral?: string | null
+  moral?: string | null,
+  fast = false
 ): Promise<string> {
   const prompt = storyIllustrationPrompt(
     { title, story: storyExcerpt, lengthMinutes: 5, moral: moral ?? undefined },
     childName ?? "the child"
   );
-  return generateCardIllustration(prompt);
+  return generateCardIllustration(prompt, fast);
 }
 
 export async function generateStoryNarration(storyText: string): Promise<Buffer> {

--- a/src/lib/services/today-page.ts
+++ b/src/lib/services/today-page.ts
@@ -1,0 +1,115 @@
+import { prisma } from "@/lib/db";
+import { toDateKey } from "@/lib/date-utils";
+import { getOrCreateDailyBrief } from "@/lib/services/daily-brief";
+import { getTodayBriefStory } from "@/lib/services/story-audio-cache";
+import { generateStoryIllustration } from "@/lib/services/story-media";
+import type { DailyBriefContent } from "@/types/daily-brief";
+
+/** Minimal data for the Today dashboard — avoids meetups, weather, and other home-only queries. */
+export async function getTodayPageData(userId: string) {
+  const [brief, profile] = await Promise.all([
+    getOrCreateDailyBrief(userId),
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        name: true,
+        childNickname: true,
+        childAge: true,
+        parentingGoals: true,
+        priorityGoal: true,
+        currentChallenges: true,
+      },
+    }),
+  ]);
+
+  return {
+    brief,
+    profile: profile ?? { name: "there" },
+  };
+}
+
+export async function getTodayBriefRecord(userId: string) {
+  return prisma.dailyBrief.findUnique({
+    where: { userId_date: { userId, date: toDateKey() } },
+    select: { content: true },
+  });
+}
+
+export async function saveTodayStoryIllustration(
+  userId: string,
+  illustrationData: string
+): Promise<DailyBriefContent> {
+  const brief = await getTodayBriefRecord(userId);
+  if (!brief) throw new Error("Today's brief not found");
+
+  const content = brief.content as unknown as DailyBriefContent;
+  content.bedtimeStory = { ...content.bedtimeStory, illustrationData };
+
+  await prisma.dailyBrief.update({
+    where: { userId_date: { userId, date: toDateKey() } },
+    data: { content: content as object },
+  });
+
+  return content;
+}
+
+export async function getCachedTodayStoryIllustration(userId: string): Promise<string | null> {
+  const brief = await getTodayBriefRecord(userId);
+  if (!brief) return null;
+  const content = brief.content as unknown as DailyBriefContent;
+  return content.bedtimeStory?.illustrationData?.trim() || null;
+}
+
+const inflightIllustration = new Map<string, Promise<string>>();
+
+export async function getOrGenerateTodayStoryIllustration(userId: string): Promise<string> {
+  const cached = await getCachedTodayStoryIllustration(userId);
+  if (cached) return cached;
+
+  const pending = inflightIllustration.get(userId);
+  if (pending) return pending;
+
+  const task = (async () => {
+    const again = await getCachedTodayStoryIllustration(userId);
+    if (again) return again;
+
+    const storyText = await getTodayBriefStory(userId);
+    if (!storyText) throw new Error("Today's story not found");
+
+    const record = await getTodayBriefRecord(userId);
+    if (!record) throw new Error("Today's brief not found");
+    const content = record.content as unknown as DailyBriefContent;
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { childNickname: true },
+    });
+
+    const illustrationData = await generateStoryIllustration(
+      content.bedtimeStory.title,
+      storyText,
+      user?.childNickname,
+      content.bedtimeStory.moral ?? null,
+      true
+    );
+
+    await saveTodayStoryIllustration(userId, illustrationData);
+    return illustrationData;
+  })();
+
+  inflightIllustration.set(userId, task);
+  try {
+    return await task;
+  } finally {
+    inflightIllustration.delete(userId);
+  }
+}
+
+export function warmTodayStoryIllustration(userId: string): void {
+  void getCachedTodayStoryIllustration(userId).then((cached) => {
+    if (cached) return;
+    return getOrGenerateTodayStoryIllustration(userId);
+  }).catch((err) => {
+    console.warn("Story illustration warm failed:", err);
+  });
+}

--- a/src/lib/story-illustration-prefetch.ts
+++ b/src/lib/story-illustration-prefetch.ts
@@ -1,0 +1,100 @@
+'use client';
+
+const illustrationCache = new Map<string, string>();
+let todayGetPrefetch: Promise<string | null> | null = null;
+let todayGenPrefetch: Promise<string> | null = null;
+
+export function cacheTodayIllustration(data: string) {
+  illustrationCache.set('today', data);
+}
+
+export function getCachedTodayIllustration(): string | undefined {
+  return illustrationCache.get('today');
+}
+
+function normalizeIllustration(data: string): string {
+  if (!data?.trim()) return data;
+  if (
+    data.startsWith('data:') ||
+    data.startsWith('http://') ||
+    data.startsWith('https://')
+  ) {
+    return data;
+  }
+  return `data:image/png;base64,${data}`;
+}
+
+/** Load cached cover art only — does not generate. */
+export function prefetchTodayStoryIllustration(): Promise<string | null> {
+  const cached = getCachedTodayIllustration();
+  if (cached) return Promise.resolve(cached);
+
+  if (todayGetPrefetch) return todayGetPrefetch;
+
+  todayGetPrefetch = fetch('/api/stories/illustrate/today')
+    .then(async (res) => {
+      if (!res.ok) return null;
+      const { illustrationData } = await res.json();
+      const normalized = normalizeIllustration(illustrationData);
+      cacheTodayIllustration(normalized);
+      return normalized;
+    })
+    .catch(() => null)
+    .finally(() => {
+      todayGetPrefetch = null;
+    });
+
+  return todayGetPrefetch;
+}
+
+/** Start generating cover art in the background (when story detail opens). */
+export function warmTodayStoryIllustration(): Promise<string | null> {
+  const cached = getCachedTodayIllustration();
+  if (cached) return Promise.resolve(cached);
+
+  if (todayGenPrefetch) {
+    return todayGenPrefetch.then((v) => v).catch(() => null);
+  }
+
+  todayGenPrefetch = fetch('/api/stories/illustrate/today', { method: 'POST' })
+    .then(async (res) => {
+      if (!res.ok) throw new Error('Generate failed');
+      const { illustrationData } = await res.json();
+      const normalized = normalizeIllustration(illustrationData);
+      cacheTodayIllustration(normalized);
+      return normalized;
+    })
+    .catch((err) => {
+      todayGenPrefetch = null;
+      throw err;
+    });
+
+  return todayGenPrefetch.catch(() => null);
+}
+
+export async function fetchTodayStoryIllustration(): Promise<string> {
+  const cached = getCachedTodayIllustration();
+  if (cached) return cached;
+
+  const fromGet = await prefetchTodayStoryIllustration();
+  if (fromGet) return fromGet;
+
+  if (todayGenPrefetch) {
+    try {
+      return await todayGenPrefetch;
+    } catch {
+      todayGenPrefetch = null;
+    }
+  }
+
+  const warmed = await warmTodayStoryIllustration();
+  if (warmed) return warmed;
+
+  throw new Error('Illustration failed');
+}
+
+export function invalidateTodayStoryIllustrationCache() {
+  illustrationCache.delete('today');
+  todayGetPrefetch = null;
+  todayGenPrefetch = null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Today page load

**Before:** Today called `/api/daily-brief`, which fetched meetups, weekend activities, weather, journal memory, and more — none of which the Today dashboard uses.

**After:** New `/api/today` returns only the daily brief + slim profile (2 parallel DB reads).

## Story cover art

**Before:** Every Cover art tap called OpenAI image generation with no cache.

**After:**
- Cover art saved on today's daily brief after first generation
- Cached cover returns instantly on repeat
- Background generation starts when Read Story opens
- Uses gpt-image-1-mini + low quality for faster first generation

## Test plan
- [ ] Today page loads faster
- [ ] Read Story — cover may appear while sheet is open
- [ ] Cover art same day — instant from cache
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a231d1e6-caff-4d6d-acd3-83f350fa4fb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a231d1e6-caff-4d6d-acd3-83f350fa4fb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

