### PR TITLE
Add recipe photo and fridge-based meal planning

### DIFF
--- a/src/app/api/recipes/illustrate/today/route.ts
+++ b/src/app/api/recipes/illustrate/today/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import {
+  getCachedTodayRecipeIllustration,
+  getOrGenerateTodayRecipeIllustration,
+} from "@/lib/services/today-page";
+
+export const maxDuration = 60;
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const imageData = await getCachedTodayRecipeIllustration(session.user.id);
+  if (!imageData) {
+    return NextResponse.json({ error: "Not generated yet" }, { status: 404 });
+  }
+
+  return NextResponse.json({ imageData });
+}
+
+export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const imageData = await getOrGenerateTodayRecipeIllustration(session.user.id);
+    return NextResponse.json({ imageData });
+  } catch (error) {
+    console.error("Today recipe illustration error:", error);
+    const message = error instanceof Error ? error.message : "Illustration failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/today/meal/from-fridge/route.ts
+++ b/src/app/api/today/meal/from-fridge/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { fetchRotateContext, updateDailyBriefSection } from "@/lib/services/daily-brief";
+import { generateRecipeFromFridge } from "@/lib/services/mumbot";
+import { warmTodayRecipeIllustration } from "@/lib/services/today-page";
+
+export const maxDuration = 60;
+
+/** Generate a personalised recipe from fridge ingredients the parent has on hand. */
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = (await request.json()) as { ingredients?: unknown };
+    const raw = body.ingredients;
+    const ingredients = (Array.isArray(raw) ? raw : [])
+      .filter((item): item is string => typeof item === "string")
+      .map((item) => item.trim())
+      .filter(Boolean);
+
+    if (ingredients.length === 0) {
+      return NextResponse.json({ error: "Add at least one ingredient" }, { status: 400 });
+    }
+
+    const { profile, memories } = await fetchRotateContext(session.user.id);
+    const recipe = await generateRecipeFromFridge(profile, memories, ingredients);
+    delete recipe.imageData;
+
+    const brief = await updateDailyBriefSection(session.user.id, "recipe", recipe);
+    warmTodayRecipeIllustration(session.user.id);
+
+    return NextResponse.json({ brief, recipe });
+  } catch (error) {
+    console.error("Fridge meal error:", error);
+    const message = error instanceof Error ? error.message : "Meal generation failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -11,7 +11,9 @@ import { TodaySectionHeader, TodayFocusCard, TodayConnectCard } from '@/componen
 import { TodayPlanCard } from '@/components/today/today-plan-card';
 import { TodayBottomSheet } from '@/components/today/today-bottom-sheet';
 import {
-  MealDetailView,
+  MealDetailProvider,
+  MealDetailContent,
+  MealDetailFooter,
   ActivityDetailView,
   StoryDetailProvider,
   StoryDetailContent,
@@ -31,6 +33,11 @@ import {
   warmTodayStoryIllustration,
   invalidateTodayStoryIllustrationCache,
 } from '@/lib/story-illustration-prefetch';
+import {
+  prefetchTodayRecipeIllustration,
+  warmTodayRecipeIllustration,
+  invalidateTodayRecipeIllustrationCache,
+} from '@/lib/recipe-illustration-prefetch';
 
 async function parseApiJson<T>(response: Response): Promise<T> {
   const text = await response.text();
@@ -129,9 +136,19 @@ export default function TodayPage() {
   }, [data?.brief?.bedtimeStory?.story]);
 
   useEffect(() => {
+    if (!data?.brief?.recipe?.subtitle) return;
+    prefetchTodayRecipeIllustration().catch(() => {});
+  }, [data?.brief?.recipe?.subtitle]);
+
+  useEffect(() => {
     if (activeDetail !== 'story' || !data?.brief?.bedtimeStory?.story) return;
     warmTodayStoryIllustration().catch(() => {});
   }, [activeDetail, data?.brief?.bedtimeStory?.story]);
+
+  useEffect(() => {
+    if (activeDetail !== 'meal' || !data?.brief?.recipe?.subtitle) return;
+    warmTodayRecipeIllustration().catch(() => {});
+  }, [activeDetail, data?.brief?.recipe?.subtitle]);
 
   const patchBrief = async (action: string, extra?: Record<string, unknown>) => {
     const res = await fetch('/api/daily-brief', {
@@ -168,6 +185,11 @@ export default function TodayPage() {
         prefetchTodayStoryIllustration().catch(() => {});
         warmTodayStoryIllustration().catch(() => {});
       }
+      if (section === 'recipe') {
+        invalidateTodayRecipeIllustrationCache();
+        prefetchTodayRecipeIllustration().catch(() => {});
+        warmTodayRecipeIllustration().catch(() => {});
+      }
       toast.success('Here\'s another idea!', { id: toastId });
     } catch {
       toast.error('Could not rotate suggestion.', { id: toastId });
@@ -179,6 +201,23 @@ export default function TodayPage() {
   const askMumbot = (prompt: string) => {
     sessionStorage.setItem('mumbot_prefill', prompt);
     router.push('/mumbot');
+  };
+
+  const createFridgeRecipe = async (ingredients: string[]) => {
+    const res = await fetch('/api/today/meal/from-fridge', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ingredients }),
+    });
+    if (!res.ok) throw new Error('Request failed');
+    const json = await res.json();
+    if (json.brief) {
+      setData((prev) => (prev ? { ...prev, brief: json.brief } : prev));
+    }
+    invalidateTodayRecipeIllustrationCache();
+    prefetchTodayRecipeIllustration().catch(() => {});
+    warmTodayRecipeIllustration().catch(() => {});
+    trackEvent('meal_from_fridge');
   };
 
   const closeDetail = () => setActiveDetail(null);
@@ -225,15 +264,7 @@ export default function TodayPage() {
   };
 
   const detailFooter =
-    activeDetail === 'meal' && brief ? (
-      <MealDetailView
-        part="footer"
-        recipe={brief.recipe}
-        childAgeDisplay={brief.childAgeDisplay}
-        onSave={() => patchBrief('save-recipe')}
-        onBack={closeDetail}
-      />
-    ) : activeDetail === 'activity' && brief ? (
+    activeDetail === 'activity' && brief ? (
       <ActivityDetailView
         part="footer"
         play={brief.play}
@@ -245,14 +276,7 @@ export default function TodayPage() {
     ) : null;
 
   const detailContent =
-    activeDetail === 'meal' && brief ? (
-      <MealDetailView
-        recipe={brief.recipe}
-        childAgeDisplay={brief.childAgeDisplay}
-        onSave={() => patchBrief('save-recipe')}
-        onBack={closeDetail}
-      />
-    ) : activeDetail === 'activity' && brief ? (
+    activeDetail === 'activity' && brief ? (
       <ActivityDetailView
         play={brief.play}
         onSave={() => patchBrief('save-activity')}
@@ -414,6 +438,23 @@ export default function TodayPage() {
             <StoryDetailContent childAgeDisplay={brief.childAgeDisplay} />
           </TodayBottomSheet>
         </StoryDetailProvider>
+      ) : activeDetail === 'meal' && brief ? (
+        <MealDetailProvider
+          recipe={brief.recipe}
+          childAgeDisplay={brief.childAgeDisplay}
+          onSave={() => patchBrief('save-recipe')}
+          onBack={closeDetail}
+          onFridgeRecipe={createFridgeRecipe}
+        >
+          <TodayBottomSheet
+            open={activeDetail !== null}
+            title={detailTitles.meal}
+            onClose={closeDetail}
+            footer={<MealDetailFooter />}
+          >
+            <MealDetailContent />
+          </TodayBottomSheet>
+        </MealDetailProvider>
       ) : (
         <TodayBottomSheet
           open={activeDetail !== null}

--- a/src/components/today/today-detail-views.tsx
+++ b/src/components/today/today-detail-views.tsx
@@ -3,7 +3,8 @@
 import { createContext, useContext, useState, useRef, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Bookmark, Loader2, ImageIcon } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Bookmark, Loader2, ImageIcon, ChefHat } from 'lucide-react';
 import type {
   DailyBriefRecipe,
   DailyBriefPlay,
@@ -14,6 +15,7 @@ import { toast } from 'sonner';
 import { useStoryAudio } from '@/hooks/use-story-audio';
 import { getTodayStoryAudioFetch } from '@/lib/story-audio-prefetch';
 import { fetchTodayStoryIllustration, prefetchTodayStoryIllustration, warmTodayStoryIllustration } from '@/lib/story-illustration-prefetch';
+import { fetchTodayRecipeIllustration, prefetchTodayRecipeIllustration, warmTodayRecipeIllustration } from '@/lib/recipe-illustration-prefetch';
 import { StoryListenButton } from '@/components/story/story-listen-button';
 
 type DetailPart = 'content' | 'footer';
@@ -26,57 +28,211 @@ function normalizeIllustrationSrc(data?: string | null): string | undefined {
   return `data:image/png;base64,${data}`;
 }
 
-export function MealDetailView({
+export function MealDetailProvider({
   recipe,
   childAgeDisplay,
   onSave,
   onBack,
-  part = 'content',
+  onFridgeRecipe,
+  children,
 }: {
   recipe: DailyBriefRecipe;
   childAgeDisplay?: string;
   onSave: () => Promise<void>;
   onBack: () => void;
-  part?: DetailPart;
+  onFridgeRecipe: (ingredients: string[]) => Promise<void>;
+  children: React.ReactNode;
 }) {
   const [saving, setSaving] = useState(false);
+  const media = useMealDetailMedia(recipe);
 
-  const footer = (
-    <div className="flex gap-2">
-      <Button
-        className="flex-1 rounded-full touch-target"
-        disabled={saving}
-        onClick={async () => {
-          setSaving(true);
-          try {
-            await onSave();
-            toast.success('Meal saved!');
-          } catch {
-            toast.error('Could not save meal.');
-          } finally {
-            setSaving(false);
-          }
-        }}
-      >
-        <Bookmark className="h-4 w-4 mr-1" />
-        {saving ? 'Saving...' : 'Save meal'}
-      </Button>
-      <Button variant="outline" className="rounded-full touch-target shrink-0" onClick={onBack}>
-        Back to Today
-      </Button>
-    </div>
+  return (
+    <MealDetailContext.Provider
+      value={{
+        ...media,
+        recipe,
+        childAgeDisplay,
+        onSave,
+        onBack,
+        onFridgeRecipe,
+        saving,
+        setSaving,
+      }}
+    >
+      {children}
+    </MealDetailContext.Provider>
   );
+}
 
-  if (part === 'footer') return footer;
+type MealDetailContextValue = Omit<ReturnType<typeof useMealDetailMedia>, never> & {
+  recipe: DailyBriefRecipe;
+  childAgeDisplay?: string;
+  onSave: () => Promise<void>;
+  onBack: () => void;
+  onFridgeRecipe: (ingredients: string[]) => Promise<void>;
+  saving: boolean;
+  setSaving: (saving: boolean) => void;
+};
+
+const MealDetailContext = createContext<MealDetailContextValue | null>(null);
+
+function useMealDetailContext() {
+  const ctx = useContext(MealDetailContext);
+  if (!ctx) throw new Error('MealDetailProvider required');
+  return ctx;
+}
+
+function useMealDetailMedia(recipe: DailyBriefRecipe) {
+  const [illustrating, setIllustrating] = useState(false);
+  const [imageData, setImageData] = useState<string | undefined>(
+    normalizeIllustrationSrc(recipe.imageData)
+  );
+  const coverRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setImageData(normalizeIllustrationSrc(recipe.imageData));
+  }, [recipe.imageData, recipe.subtitle]);
+
+  useEffect(() => {
+    if (recipe.imageData) return;
+    void prefetchTodayRecipeIllustration().then((data) => {
+      if (data) setImageData(normalizeIllustrationSrc(data));
+    });
+    void warmTodayRecipeIllustration().then((data) => {
+      if (data) setImageData(normalizeIllustrationSrc(data));
+    }).catch(() => {});
+  }, [recipe.subtitle, recipe.imageData]);
+
+  const handleIllustrate = async () => {
+    setIllustrating(true);
+    try {
+      const data = await fetchTodayRecipeIllustration();
+      setImageData(normalizeIllustrationSrc(data));
+      toast.success('Recipe photo ready!');
+      requestAnimationFrame(() => {
+        coverRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      });
+    } catch {
+      toast.error('Could not generate recipe photo.');
+    } finally {
+      setIllustrating(false);
+    }
+  };
+
+  return { illustrating, imageData, coverRef, handleIllustrate };
+}
+
+export function MealDetailContent() {
+  const {
+    recipe,
+    childAgeDisplay,
+    onFridgeRecipe,
+    illustrating,
+    imageData,
+    coverRef,
+    handleIllustrate,
+  } = useMealDetailContext();
+  const [fridgeInput, setFridgeInput] = useState('');
+  const [generating, setGenerating] = useState(false);
+
+  const handleFridgeRecipe = async () => {
+    const ingredients = fridgeInput
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (ingredients.length === 0) {
+      toast.error('Add at least one ingredient from your fridge.');
+      return;
+    }
+    setGenerating(true);
+    try {
+      await onFridgeRecipe(ingredients);
+      toast.success('New meal plan ready!');
+    } catch {
+      toast.error('Could not create meal from those ingredients.');
+    } finally {
+      setGenerating(false);
+    }
+  };
 
   return (
     <div className="space-y-4 text-sm pb-2">
+      <div ref={coverRef} className="space-y-2">
+        {imageData ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={imageData}
+            alt={`Photo of ${recipe.subtitle}`}
+            className="w-full rounded-2xl max-h-44 object-cover"
+          />
+        ) : (
+          <div className="w-full rounded-2xl max-h-44 min-h-[8rem] bg-gradient-to-br from-amber-50 to-orange-50 flex items-center justify-center text-muted-foreground text-xs px-4 text-center">
+            Tap Recipe photo to generate an appetising picture
+          </div>
+        )}
+        <Button
+          size="sm"
+          variant="outline"
+          className="rounded-full touch-target w-full"
+          disabled={illustrating}
+          onClick={handleIllustrate}
+        >
+          {illustrating ? (
+            <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
+          ) : (
+            <ImageIcon className="h-3.5 w-3.5 mr-1" />
+          )}
+          Recipe photo
+        </Button>
+      </div>
+
       <div>
         <h3 className="text-lg font-bold">{recipe.subtitle}</h3>
         {childAgeDisplay && (
           <p className="text-xs text-muted-foreground mt-1">Suitable for {childAgeDisplay}</p>
         )}
+        {recipe.prepTimeMinutes > 0 && (
+          <Badge variant="secondary" className="rounded-full mt-2">
+            {recipe.prepTimeMinutes} min
+          </Badge>
+        )}
       </div>
+
+      <div className="bg-amber-50/80 rounded-xl p-3 space-y-2 border border-amber-100">
+        <p className="text-xs font-medium text-amber-900 flex items-center gap-1.5">
+          <ChefHat className="h-3.5 w-3.5" />
+          What&apos;s in your fridge?
+        </p>
+        <p className="text-xs text-amber-800/80">
+          List ingredients you have on hand — we&apos;ll suggest a child-friendly meal.
+        </p>
+        <Input
+          value={fridgeInput}
+          onChange={(e) => setFridgeInput(e.target.value)}
+          placeholder="e.g. salmon, broccoli, rice"
+          className="rounded-xl bg-white border-amber-200"
+          disabled={generating}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') void handleFridgeRecipe();
+          }}
+        />
+        <Button
+          size="sm"
+          className="rounded-full w-full touch-target"
+          disabled={generating || !fridgeInput.trim()}
+          onClick={() => void handleFridgeRecipe()}
+        >
+          {generating ? (
+            <>
+              <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
+              Creating meal plan…
+            </>
+          ) : (
+            'Create meal from fridge'
+          )}
+        </Button>
+      </div>
+
       <div>
         <p className="text-xs font-medium uppercase text-muted-foreground mb-1">Why it helps</p>
         <p className="leading-relaxed">{recipe.whyThisMeal}</p>
@@ -103,6 +259,36 @@ export function MealDetailView({
           ))}
         </ol>
       </div>
+    </div>
+  );
+}
+
+export function MealDetailFooter() {
+  const { onSave, onBack, saving, setSaving } = useMealDetailContext();
+
+  return (
+    <div className="flex gap-2">
+      <Button
+        className="flex-1 rounded-full touch-target"
+        disabled={saving}
+        onClick={async () => {
+          setSaving(true);
+          try {
+            await onSave();
+            toast.success('Meal saved!');
+          } catch {
+            toast.error('Could not save meal.');
+          } finally {
+            setSaving(false);
+          }
+        }}
+      >
+        <Bookmark className="h-4 w-4 mr-1" />
+        {saving ? 'Saving...' : 'Save meal'}
+      </Button>
+      <Button variant="outline" className="rounded-full touch-target shrink-0" onClick={onBack}>
+        Back to Today
+      </Button>
     </div>
   );
 }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -11,6 +11,7 @@ export type AnalyticsEvent =
   | "today_dashboard_viewed"
   | "mumbot_question"
   | "meal_clicked"
+  | "meal_from_fridge"
   | "story_clicked"
   | "activity_clicked"
   | "connect_status_created"

--- a/src/lib/recipe-illustration-prefetch.ts
+++ b/src/lib/recipe-illustration-prefetch.ts
@@ -1,0 +1,100 @@
+'use client';
+
+const illustrationCache = new Map<string, string>();
+let todayGetPrefetch: Promise<string | null> | null = null;
+let todayGenPrefetch: Promise<string> | null = null;
+
+export function cacheTodayRecipeIllustration(data: string) {
+  illustrationCache.set('today-recipe', data);
+}
+
+export function getCachedTodayRecipeIllustration(): string | undefined {
+  return illustrationCache.get('today-recipe');
+}
+
+function normalizeIllustration(data: string): string {
+  if (!data?.trim()) return data;
+  if (
+    data.startsWith('data:') ||
+    data.startsWith('http://') ||
+    data.startsWith('https://')
+  ) {
+    return data;
+  }
+  return `data:image/png;base64,${data}`;
+}
+
+/** Load cached recipe photo only — does not generate. */
+export function prefetchTodayRecipeIllustration(): Promise<string | null> {
+  const cached = getCachedTodayRecipeIllustration();
+  if (cached) return Promise.resolve(cached);
+
+  if (todayGetPrefetch) return todayGetPrefetch;
+
+  todayGetPrefetch = fetch('/api/recipes/illustrate/today')
+    .then(async (res) => {
+      if (!res.ok) return null;
+      const { imageData } = await res.json();
+      const normalized = normalizeIllustration(imageData);
+      cacheTodayRecipeIllustration(normalized);
+      return normalized;
+    })
+    .catch(() => null)
+    .finally(() => {
+      todayGetPrefetch = null;
+    });
+
+  return todayGetPrefetch;
+}
+
+/** Start generating recipe photo in the background (when meal detail opens). */
+export function warmTodayRecipeIllustration(): Promise<string | null> {
+  const cached = getCachedTodayRecipeIllustration();
+  if (cached) return Promise.resolve(cached);
+
+  if (todayGenPrefetch) {
+    return todayGenPrefetch.then((v) => v).catch(() => null);
+  }
+
+  todayGenPrefetch = fetch('/api/recipes/illustrate/today', { method: 'POST' })
+    .then(async (res) => {
+      if (!res.ok) throw new Error('Generate failed');
+      const { imageData } = await res.json();
+      const normalized = normalizeIllustration(imageData);
+      cacheTodayRecipeIllustration(normalized);
+      return normalized;
+    })
+    .catch((err) => {
+      todayGenPrefetch = null;
+      throw err;
+    });
+
+  return todayGenPrefetch.catch(() => null);
+}
+
+export async function fetchTodayRecipeIllustration(): Promise<string> {
+  const cached = getCachedTodayRecipeIllustration();
+  if (cached) return cached;
+
+  const fromGet = await prefetchTodayRecipeIllustration();
+  if (fromGet) return fromGet;
+
+  if (todayGenPrefetch) {
+    try {
+      return await todayGenPrefetch;
+    } catch {
+      todayGenPrefetch = null;
+    }
+  }
+
+  const warmed = await warmTodayRecipeIllustration();
+  if (warmed) return warmed;
+
+  throw new Error('Illustration failed');
+}
+
+export function invalidateTodayRecipeIllustrationCache() {
+  illustrationCache.delete('today-recipe');
+  todayGetPrefetch = null;
+  todayGenPrefetch = null;
+}

--- a/src/lib/services/mumbot.ts
+++ b/src/lib/services/mumbot.ts
@@ -410,6 +410,35 @@ export async function regenerateRecipe(
   }
 }
 
+export async function generateRecipeFromFridge(
+  profile: BriefProfile,
+  memories: BriefMemory[],
+  ingredients: string[]
+): Promise<DailyBriefRecipe> {
+  const context = buildDailyBriefContext(profile, memories, []);
+  const fridgeList = ingredients.join(", ");
+
+  const completion = await openai.chat.completions.create({
+    model: OPENAI_MODEL,
+    messages: [
+      {
+        role: "system",
+        content: `Create ONE child-friendly meal or recipe using these fridge ingredients as the main focus: ${fridgeList}. You may add small pantry staples (oil, salt, herbs) only if needed. Return JSON: { "title", "subtitle", "prepTimeMinutes", "whyThisMeal", "ingredients": [], "steps": [], "healthyTip": "optional" }. Keep steps short (3-4). Make it practical for a busy parent. ${BRIEF_TONE_RULES}`,
+      },
+      { role: "user", content: `${context}\n\nAvailable from the fridge: ${fridgeList}` },
+    ],
+    temperature: 0.85,
+    max_tokens: 550,
+    response_format: { type: "json_object" },
+  });
+
+  try {
+    return JSON.parse(completion.choices[0]?.message?.content || "{}") as DailyBriefRecipe;
+  } catch {
+    return defaultDailyBrief(profile).recipe;
+  }
+}
+
 export async function regeneratePlay(
   profile: BriefProfile,
   memories: BriefMemory[],

--- a/src/lib/services/today-page.ts
+++ b/src/lib/services/today-page.ts
@@ -1,6 +1,8 @@
 import { prisma } from "@/lib/db";
 import { toDateKey } from "@/lib/date-utils";
 import { getOrCreateDailyBrief } from "@/lib/services/daily-brief";
+import { recipeIllustrationPrompt } from "@/lib/illustration-prompts";
+import { generateCardIllustration } from "@/lib/services/card-illustrations";
 import { getTodayBriefStory } from "@/lib/services/story-audio-cache";
 import { generateStoryIllustration } from "@/lib/services/story-media";
 import type { DailyBriefContent } from "@/types/daily-brief";
@@ -111,5 +113,71 @@ export function warmTodayStoryIllustration(userId: string): void {
     return getOrGenerateTodayStoryIllustration(userId);
   }).catch((err) => {
     console.warn("Story illustration warm failed:", err);
+  });
+}
+
+export async function saveTodayRecipeIllustration(
+  userId: string,
+  imageData: string
+): Promise<DailyBriefContent> {
+  const brief = await getTodayBriefRecord(userId);
+  if (!brief) throw new Error("Today's brief not found");
+
+  const content = brief.content as unknown as DailyBriefContent;
+  content.recipe = { ...content.recipe, imageData };
+
+  await prisma.dailyBrief.update({
+    where: { userId_date: { userId, date: toDateKey() } },
+    data: { content: content as object },
+  });
+
+  return content;
+}
+
+export async function getCachedTodayRecipeIllustration(userId: string): Promise<string | null> {
+  const brief = await getTodayBriefRecord(userId);
+  if (!brief) return null;
+  const content = brief.content as unknown as DailyBriefContent;
+  return content.recipe?.imageData?.trim() || null;
+}
+
+const inflightRecipeIllustration = new Map<string, Promise<string>>();
+
+export async function getOrGenerateTodayRecipeIllustration(userId: string): Promise<string> {
+  const cached = await getCachedTodayRecipeIllustration(userId);
+  if (cached) return cached;
+
+  const pending = inflightRecipeIllustration.get(userId);
+  if (pending) return pending;
+
+  const task = (async () => {
+    const again = await getCachedTodayRecipeIllustration(userId);
+    if (again) return again;
+
+    const record = await getTodayBriefRecord(userId);
+    if (!record) throw new Error("Today's brief not found");
+    const content = record.content as unknown as DailyBriefContent;
+
+    const prompt = recipeIllustrationPrompt(content.recipe);
+    const imageData = await generateCardIllustration(prompt, true);
+
+    await saveTodayRecipeIllustration(userId, imageData);
+    return imageData;
+  })();
+
+  inflightRecipeIllustration.set(userId, task);
+  try {
+    return await task;
+  } finally {
+    inflightRecipeIllustration.delete(userId);
+  }
+}
+
+export function warmTodayRecipeIllustration(userId: string): void {
+  void getCachedTodayRecipeIllustration(userId).then((cached) => {
+    if (cached) return;
+    return getOrGenerateTodayRecipeIllustration(userId);
+  }).catch((err) => {
+    console.warn("Recipe illustration warm failed:", err);
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enhances the Today meal feature with two mum-requested capabilities:

1. **Recipe photo** — Meal detail now shows an AI-generated appetising photo of today's recipe (same pattern as story cover art), with background prefetch when opening the meal sheet.
2. **Fridge ingredients → meal plan** — Mums can list what's on hand (e.g. salmon, broccoli, rice) and get a personalised child-friendly recipe that uses those ingredients.

## Changes

- `MealDetailProvider` / `MealDetailContent` / `MealDetailFooter` — hero recipe image, "Recipe photo" button, and fridge input UI
- `GET/POST /api/recipes/illustrate/today` — cached recipe illustration for today's brief
- `POST /api/today/meal/from-fridge` — generates a new recipe from supplied ingredients
- `generateRecipeFromFridge()` in mumbot — respects profile food preferences and child age
- Client prefetch module `recipe-illustration-prefetch.ts` mirroring story illustration flow

## How to test

1. Open **Today → View Meal**
2. Tap **Recipe photo** (or wait for background generation) — image should appear at top
3. Enter fridge ingredients (comma-separated) and tap **Create meal from fridge**
4. Recipe title, ingredients, and steps should update; a new photo generates in the background
5. **Try another** on the meal card should also refresh the recipe and invalidate the photo cache
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a231d1e6-caff-4d6d-acd3-83f350fa4fb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a231d1e6-caff-4d6d-acd3-83f350fa4fb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

