### PR TITLE
Fix recipe links to open exact videos and recipe pages

### DIFF
--- a/src/app/api/recipes/resolve-links/route.ts
+++ b/src/app/api/recipes/resolve-links/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { attachRecipeSampleLinks } from "@/lib/services/recipe-link-resolver";
+import { isGenericRecipeLink } from "@/lib/recipe-link-utils";
+import type { DailyBriefRecipe } from "@/types/daily-brief";
+
+export const maxDuration = 30;
+
+/** Resolve exact YouTube video + recipe article links for a generated dish. */
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = (await request.json()) as { recipe?: DailyBriefRecipe };
+    const recipe = body.recipe;
+    if (!recipe?.subtitle || !Array.isArray(recipe.ingredients)) {
+      return NextResponse.json({ error: "Invalid recipe" }, { status: 400 });
+    }
+
+    const needsResolve =
+      !recipe.sampleLinks?.length ||
+      recipe.sampleLinks.some((link) => isGenericRecipeLink(link.url));
+
+    if (!needsResolve) {
+      return NextResponse.json({ sampleLinks: recipe.sampleLinks });
+    }
+
+    const updated = await attachRecipeSampleLinks(recipe);
+    return NextResponse.json({ sampleLinks: updated.sampleLinks ?? [] });
+  } catch (error) {
+    console.error("Resolve recipe links error:", error);
+    const message = error instanceof Error ? error.message : "Link resolution failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/saved/page.tsx
+++ b/src/app/saved/page.tsx
@@ -13,7 +13,6 @@ import {
   Loader2, ImageIcon, ChevronDown, ChevronUp
 } from 'lucide-react';
 import type { DailyBriefRecipe } from '@/types/daily-brief';
-import { buildRecipeSampleLinks } from '@/lib/recipe-sample-links';
 import { ExternalLink, Youtube, FileText } from 'lucide-react';
 import { format } from 'date-fns';
 import { toast } from 'sonner';
@@ -254,7 +253,7 @@ function SavedPageContent() {
                         <ol className="list-decimal list-inside text-muted-foreground space-y-1">
                           {recipe.steps?.map((s, idx) => <li key={idx}>{s}</li>)}
                         </ol>
-                        {(recipe.sampleLinks?.length ? recipe.sampleLinks : buildRecipeSampleLinks(recipe)).map((link) => (
+                        {(recipe.sampleLinks ?? []).map((link) => (
                           <a
                             key={link.url}
                             href={link.url}

--- a/src/components/today/today-detail-views.tsx
+++ b/src/components/today/today-detail-views.tsx
@@ -17,8 +17,8 @@ import { useStoryAudio } from '@/hooks/use-story-audio';
 import { getTodayStoryAudioFetch } from '@/lib/story-audio-prefetch';
 import { fetchTodayStoryIllustration, prefetchTodayStoryIllustration, warmTodayStoryIllustration } from '@/lib/story-illustration-prefetch';
 import { fetchTodayRecipeIllustration, prefetchTodayRecipeIllustration, warmTodayRecipeIllustration } from '@/lib/recipe-illustration-prefetch';
+import { isGenericRecipeLink } from '@/lib/recipe-link-utils';
 import { StoryListenButton } from '@/components/story/story-listen-button';
-import { buildRecipeSampleLinks } from '@/lib/recipe-sample-links';
 
 const MEAL_STYLE_OPTIONS = ['Soup', 'Pasta', 'Rice bowl', 'Salad', 'Stir-fry', 'Sandwich', 'Casserole', 'Smoothie'] as const;
 
@@ -132,7 +132,19 @@ function useMealDetailMedia(recipe: DailyBriefRecipe) {
   return { illustrating, imageData, coverRef, handleIllustrate };
 }
 
-function RecipeSampleLinks({ links }: { links: RecipeSampleLink[] }) {
+function RecipeSampleLinks({ links, loading }: { links: RecipeSampleLink[]; loading?: boolean }) {
+  if (loading) {
+    return (
+      <div className="space-y-2">
+        <p className="text-xs font-medium uppercase text-muted-foreground">Recipe inspiration</p>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground rounded-xl border bg-muted/20 px-3 py-2.5">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          Finding matching videos and recipes…
+        </div>
+      </div>
+    );
+  }
+
   if (!links.length) return null;
 
   return (
@@ -221,8 +233,46 @@ export function MealDetailContent() {
     }
   };
 
-  const sampleLinks =
-    recipe.sampleLinks?.length ? recipe.sampleLinks : buildRecipeSampleLinks(recipe);
+  const [sampleLinks, setSampleLinks] = useState<RecipeSampleLink[]>(recipe.sampleLinks ?? []);
+  const [linksLoading, setLinksLoading] = useState(false);
+
+  useEffect(() => {
+    const existing = recipe.sampleLinks ?? [];
+    const needsResolve =
+      !existing.length || existing.some((link) => isGenericRecipeLink(link.url));
+
+    if (!needsResolve) {
+      setSampleLinks(existing);
+      return;
+    }
+
+    let cancelled = false;
+    setLinksLoading(true);
+    void fetch('/api/recipes/resolve-links', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ recipe }),
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error('Failed');
+        return res.json() as Promise<{ sampleLinks?: RecipeSampleLink[] }>;
+      })
+      .then((data) => {
+        if (!cancelled && data.sampleLinks?.length) {
+          setSampleLinks(data.sampleLinks);
+        }
+      })
+      .catch(() => {
+        if (!cancelled && existing.length) setSampleLinks(existing);
+      })
+      .finally(() => {
+        if (!cancelled) setLinksLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [recipe.subtitle, recipe.ingredients, recipe.steps, recipe.sampleLinks]);
 
   return (
     <div className="space-y-4 text-sm pb-2">
@@ -377,7 +427,7 @@ export function MealDetailContent() {
           <p className="text-sm">{recipe.healthyTip}</p>
         </div>
       )}
-      <RecipeSampleLinks links={sampleLinks} />
+      <RecipeSampleLinks links={sampleLinks} loading={linksLoading} />
       <div>
         <p className="text-xs font-medium uppercase text-muted-foreground mb-2">Ingredients</p>
         <ul className="list-disc pl-4 space-y-1 text-muted-foreground">

--- a/src/lib/recipe-link-utils.ts
+++ b/src/lib/recipe-link-utils.ts
@@ -1,0 +1,13 @@
+/** Shared helpers for recipe inspiration links (safe for client + server). */
+export function isGenericRecipeLink(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      (parsed.hostname.includes("youtube.com") && parsed.pathname === "/results") ||
+      (parsed.hostname.includes("google.com") && parsed.pathname === "/search") ||
+      (parsed.hostname.includes("search.brave.com") && parsed.pathname === "/search")
+    );
+  } catch {
+    return true;
+  }
+}

--- a/src/lib/recipe-sample-links.ts
+++ b/src/lib/recipe-sample-links.ts
@@ -1,31 +1,7 @@
-import type { DailyBriefRecipe, RecipeSampleLink } from "@/types/daily-brief";
+import type { DailyBriefRecipe } from "@/types/daily-brief";
+import { attachRecipeSampleLinks } from "@/lib/services/recipe-link-resolver";
 
-function encodeQuery(text: string): string {
-  return encodeURIComponent(text.trim());
-}
-
-/** Build reliable search links for recipe inspiration (no hallucinated video IDs). */
-export function buildRecipeSampleLinks(recipe: DailyBriefRecipe): RecipeSampleLink[] {
-  const base = `${recipe.subtitle} toddler recipe`;
-  const query = encodeQuery(base);
-  return [
-    {
-      title: `Watch ${recipe.subtitle} on YouTube`,
-      url: `https://www.youtube.com/results?search_query=${query}`,
-      type: "youtube",
-    },
-    {
-      title: `${recipe.subtitle} — recipe articles & guides`,
-      url: `https://www.google.com/search?q=${query}`,
-      type: "article",
-    },
-  ];
-}
-
-export function withRecipeSampleLinks(recipe: DailyBriefRecipe): DailyBriefRecipe {
-  const links =
-    recipe.sampleLinks?.length && recipe.sampleLinks.every((l) => l.url?.startsWith("http"))
-      ? recipe.sampleLinks
-      : buildRecipeSampleLinks(recipe);
-  return { ...recipe, sampleLinks: links };
+/** @deprecated Use attachRecipeSampleLinks from recipe-link-resolver */
+export async function withRecipeSampleLinks(recipe: DailyBriefRecipe): Promise<DailyBriefRecipe> {
+  return attachRecipeSampleLinks(recipe);
 }

--- a/src/lib/services/mumbot.ts
+++ b/src/lib/services/mumbot.ts
@@ -435,7 +435,7 @@ export async function generateRecipeFromFridge(
     messages: [
       {
         role: "system",
-        content: `Create ONE child-friendly meal or recipe using these fridge ingredients as the main focus: ${fridgeList}. You may add small pantry staples (oil, salt, herbs) only if needed.${prefLine}${avoid} Return JSON: { "title", "subtitle", "prepTimeMinutes", "whyThisMeal", "ingredients": [], "steps": [], "healthyTip": "optional", "sampleLinks": [{ "title": "short link label", "searchQuery": "search terms for this dish", "type": "youtube" | "article" }] }. Include exactly 2 sampleLinks (one youtube, one article) with helpful searchQuery strings — real URLs are added server-side. Keep steps short (3-4). Make it practical for a busy parent. ${BRIEF_TONE_RULES}`,
+        content: `Create ONE child-friendly meal or recipe using these fridge ingredients as the main focus: ${fridgeList}. You may add small pantry staples (oil, salt, herbs) only if needed.${prefLine}${avoid} Return JSON: { "title", "subtitle", "prepTimeMinutes", "whyThisMeal", "ingredients": [], "steps": [], "healthyTip": "optional" }. Keep steps short (3-4). Make it practical for a busy parent. ${BRIEF_TONE_RULES}`,
       },
       { role: "user", content: `${context}\n\nAvailable from the fridge: ${fridgeList}${prefLine}` },
     ],
@@ -445,8 +445,7 @@ export async function generateRecipeFromFridge(
   });
 
   try {
-    type RawSampleLink = { title?: string; searchQuery?: string; type?: string; url?: string };
-    type RawFridgeRecipe = Omit<DailyBriefRecipe, "sampleLinks"> & { sampleLinks?: RawSampleLink[] };
+    type RawFridgeRecipe = Omit<DailyBriefRecipe, "sampleLinks">;
     const parsed = JSON.parse(completion.choices[0]?.message?.content || "{}") as RawFridgeRecipe;
     const recipe: DailyBriefRecipe = {
       title: parsed.title,
@@ -458,25 +457,9 @@ export async function generateRecipeFromFridge(
       healthyTip: parsed.healthyTip,
       fromFridge: true,
     };
-    if (Array.isArray(parsed.sampleLinks)) {
-      recipe.sampleLinks = parsed.sampleLinks
-        .filter((link) => link?.title && (link.searchQuery || link.url))
-        .slice(0, 3)
-        .map((link) => {
-          const type = link.type === "youtube" ? "youtube" : "article";
-          const query = encodeURIComponent((link.searchQuery || link.title || recipe.subtitle).trim());
-          const url =
-            link.url?.startsWith("http")
-              ? link.url
-              : type === "youtube"
-                ? `https://www.youtube.com/results?search_query=${query}`
-                : `https://www.google.com/search?q=${query}`;
-          return { title: link.title!, url, type };
-        });
-    }
-    return withRecipeSampleLinks(recipe);
+    return await withRecipeSampleLinks(recipe);
   } catch {
-    return withRecipeSampleLinks({ ...defaultDailyBrief(profile).recipe, fromFridge: true });
+    return await withRecipeSampleLinks({ ...defaultDailyBrief(profile).recipe, fromFridge: true });
   }
 }
 

--- a/src/lib/services/recipe-link-resolver.ts
+++ b/src/lib/services/recipe-link-resolver.ts
@@ -1,0 +1,238 @@
+import type { DailyBriefRecipe, RecipeSampleLink } from "@/types/daily-brief";
+import { isGenericRecipeLink } from "@/lib/recipe-link-utils";
+
+const USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+let innerTubeCache: { apiKey: string; clientVersion: string; fetchedAt: number } | null = null;
+const INNERTUBE_TTL_MS = 60 * 60 * 1000;
+
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((w) => w.length > 2)
+  );
+}
+
+function scoreRecipeMatch(title: string, recipe: DailyBriefRecipe): number {
+  const recipeTokens = tokenize(`${recipe.subtitle} ${recipe.title} ${recipe.ingredients.join(" ")}`);
+  const titleTokens = Array.from(tokenize(title));
+  if (!titleTokens.length) return 0;
+  let score = 0;
+  for (const token of titleTokens) {
+    if (recipeTokens.has(token)) score += 2;
+  }
+  const subtitleTokens = Array.from(tokenize(recipe.subtitle));
+  for (const token of subtitleTokens) {
+    if (title.toLowerCase().includes(token)) score += 3;
+  }
+  return score;
+}
+
+function slugToTitle(slug: string): string {
+  return slug
+    .split("-")
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+/** Build a precise search query from the full generated recipe. */
+export function buildRecipeSearchQuery(recipe: DailyBriefRecipe): string {
+  const ingredients = recipe.ingredients.slice(0, 6).join(" ");
+  const technique = recipe.steps[0]?.replace(/\.$/, "") ?? "";
+  return [recipe.subtitle, ingredients, technique].filter(Boolean).join(" ").trim();
+}
+
+async function getInnerTubeConfig(): Promise<{ apiKey: string; clientVersion: string }> {
+  if (innerTubeCache && Date.now() - innerTubeCache.fetchedAt < INNERTUBE_TTL_MS) {
+    return innerTubeCache;
+  }
+
+  const res = await fetch("https://www.youtube.com", {
+    headers: { "User-Agent": USER_AGENT },
+    signal: AbortSignal.timeout(8000),
+  });
+  const html = await res.text();
+  const apiKey = html.match(/"INNERTUBE_API_KEY":"([^"]+)"/)?.[1];
+  const clientVersion = html.match(/"INNERTUBE_CLIENT_VERSION":"([^"]+)"/)?.[1] ?? "2.20260101.00.00";
+  if (!apiKey) throw new Error("Could not read YouTube config");
+
+  innerTubeCache = { apiKey, clientVersion, fetchedAt: Date.now() };
+  return innerTubeCache;
+}
+
+type YoutubeCandidate = { videoId: string; title: string; url: string };
+
+async function searchYoutubeCandidates(query: string): Promise<YoutubeCandidate[]> {
+  const { apiKey, clientVersion } = await getInnerTubeConfig();
+  const res = await fetch(`https://www.youtube.com/youtubei/v1/search?key=${apiKey}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "User-Agent": USER_AGENT,
+    },
+    body: JSON.stringify({
+      context: {
+        client: { clientName: "WEB", clientVersion, hl: "en", gl: "US" },
+      },
+      query,
+    }),
+    signal: AbortSignal.timeout(10000),
+  });
+
+  if (!res.ok) throw new Error(`YouTube search failed (${res.status})`);
+
+  const data = (await res.json()) as {
+    contents?: {
+      twoColumnSearchResultsRenderer?: {
+        primaryContents?: {
+          sectionListRenderer?: {
+            contents?: Array<{
+              itemSectionRenderer?: {
+                contents?: Array<{
+                  videoRenderer?: {
+                    videoId?: string;
+                    title?: { runs?: Array<{ text?: string }> };
+                  };
+                }>;
+              };
+            }>;
+          };
+        };
+      };
+    };
+  };
+
+  const items =
+    data.contents?.twoColumnSearchResultsRenderer?.primaryContents?.sectionListRenderer?.contents?.[0]
+      ?.itemSectionRenderer?.contents ?? [];
+
+  const candidates: YoutubeCandidate[] = [];
+  for (const item of items) {
+    const video = item.videoRenderer;
+    if (!video?.videoId) continue;
+    const title = video.title?.runs?.[0]?.text?.trim();
+    if (!title) continue;
+    candidates.push({
+      videoId: video.videoId,
+      title,
+      url: `https://www.youtube.com/watch?v=${video.videoId}`,
+    });
+    if (candidates.length >= 8) break;
+  }
+
+  return candidates;
+}
+
+async function resolveYoutubeLink(recipe: DailyBriefRecipe): Promise<RecipeSampleLink | null> {
+  const query = `${buildRecipeSearchQuery(recipe)} recipe`;
+  const candidates = await searchYoutubeCandidates(query);
+  if (!candidates.length) return null;
+
+  const ranked = candidates.slice().sort(
+    (a, b) => scoreRecipeMatch(b.title, recipe) - scoreRecipeMatch(a.title, recipe)
+  );
+  const best = ranked[0];
+  return {
+    title: best.title,
+    url: best.url,
+    type: "youtube",
+  };
+}
+
+async function resolveArticleLink(recipe: DailyBriefRecipe): Promise<RecipeSampleLink | null> {
+  const baseQuery = buildRecipeSearchQuery(recipe);
+  const queries = [
+    `${baseQuery} recipe site:bbcgoodfood.com`,
+    `${recipe.subtitle} ${recipe.ingredients.slice(0, 4).join(" ")} recipe site:bbcgoodfood.com`,
+  ];
+
+  for (const query of queries) {
+    const res = await fetch(`https://search.brave.com/search?q=${encodeURIComponent(query)}&source=web`, {
+      headers: { "User-Agent": USER_AGENT },
+      signal: AbortSignal.timeout(10000),
+    });
+    if (!res.ok) continue;
+
+    const html = await res.text();
+    const urls = Array.from(
+      new Set(
+        Array.from(html.matchAll(/https:\/\/www\.bbcgoodfood\.com\/recipes\/[a-z0-9-]+/g)).map((m) => m[0])
+      )
+    ).filter((url) => !url.endsWith("/collection") && !url.includes("/how-to-"));
+
+    if (!urls.length) continue;
+
+    const ranked = urls
+      .map((url) => {
+        const slug = url.split("/").pop() ?? "";
+        const title = slugToTitle(slug);
+        return { url, title, score: scoreRecipeMatch(title, recipe) };
+      })
+      .sort((a, b) => b.score - a.score);
+
+    const best = ranked[0];
+    if (!best) continue;
+
+    return {
+      title: best.title,
+      url: best.url.split("?")[0],
+      type: "article",
+    };
+  }
+
+  return null;
+}
+
+function fallbackLinks(recipe: DailyBriefRecipe): RecipeSampleLink[] {
+  const query = encodeURIComponent(buildRecipeSearchQuery(recipe));
+  return [
+    {
+      title: `Find videos for ${recipe.subtitle}`,
+      url: `https://www.youtube.com/results?search_query=${query}`,
+      type: "youtube",
+    },
+    {
+      title: `Find articles for ${recipe.subtitle}`,
+      url: `https://search.brave.com/search?q=${encodeURIComponent(`${buildRecipeSearchQuery(recipe)} recipe site:bbcgoodfood.com`)}`,
+      type: "article",
+    },
+  ];
+}
+
+/** Resolve direct YouTube video + BBC Good Food recipe URLs for this exact dish. */
+export async function resolveRecipeSampleLinks(recipe: DailyBriefRecipe): Promise<RecipeSampleLink[]> {
+  const [youtube, article] = await Promise.allSettled([
+    resolveYoutubeLink(recipe),
+    resolveArticleLink(recipe),
+  ]);
+
+  const links: RecipeSampleLink[] = [];
+  if (youtube.status === "fulfilled" && youtube.value) links.push(youtube.value);
+  if (article.status === "fulfilled" && article.value) links.push(article.value);
+
+  if (links.length >= 2) return links;
+  if (links.length === 1) {
+    const fallbacks = fallbackLinks(recipe);
+    const missingType = links[0].type === "youtube" ? "article" : "youtube";
+    const extra = fallbacks.find((l) => l.type === missingType);
+    if (extra) links.push(extra);
+    return links;
+  }
+
+  return fallbackLinks(recipe);
+}
+
+export async function attachRecipeSampleLinks(recipe: DailyBriefRecipe): Promise<DailyBriefRecipe> {
+  const needsResolve =
+    !recipe.sampleLinks?.length ||
+    recipe.sampleLinks.some((link) => isGenericRecipeLink(link.url));
+
+  if (!needsResolve) return recipe;
+
+  const sampleLinks = await resolveRecipeSampleLinks(recipe);
+  return { ...recipe, sampleLinks };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes recipe inspiration links to point to **specific videos and recipe pages** instead of generic search results.

### What changed
- **YouTube**: finds a matching cooking video via InnerTube search, scored against your recipe title + ingredients → direct `youtube.com/watch?v=…` link
- **Article**: finds a matching BBC Good Food recipe page → direct recipe URL (e.g. `/recipes/cheesy-broccoli-pasta-bake`)
- Resolves links when generating fridge meals and when opening meal detail (upgrades old generic links)

## How to test
1. Today → View Meal → create a fridge meal (e.g. salmon, broccoli, pasta + Pasta style)
2. Open **Recipe inspiration** links — should land on one specific video and one BBC Good Food recipe, not a search page
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a231d1e6-caff-4d6d-acd3-83f350fa4fb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a231d1e6-caff-4d6d-acd3-83f350fa4fb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

