### PR TITLE
PostHog analytics and founder dashboard for beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,8 @@
         "next-auth": "^4.24.11",
         "next-themes": "^0.2.1",
         "openai": "^4.98.0",
+        "posthog-js": "^1.396.6",
+        "posthog-node": "^5.21.2",
         "react": "18.2.0",
         "react-day-picker": "^9.6.7",
         "react-dom": "18.2.0",
@@ -783,6 +785,21 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.39.6",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.39.6.tgz",
+      "integrity": "sha512-o6ajIwN5zXoNP0D4H/QPmOyibNTUkSyOR6ya7AG5U2ywXx4awo72L2KnCoiZPQM5x/bXv6jPBdimH8M18Ax0aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.392.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.392.1",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.392.1.tgz",
+      "integrity": "sha512-Qg6Gl7/1vlr8+gPtBi5gwnLgAgiyFoKOVmTvTtDcvya9cpTwZfna7rQmkGQ4B63CunUYNNbOlqcwiUwUDyTK6w==",
+      "license": "MIT"
     },
     "node_modules/@prisma/client": {
       "version": "6.8.2",
@@ -2870,6 +2887,13 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@typescript-eslint/parser": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
@@ -4072,6 +4096,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -4329,6 +4364,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -5157,6 +5201,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -7575,6 +7625,53 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/posthog-js": {
+      "version": "1.396.6",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.396.6.tgz",
+      "integrity": "sha512-ARI5k7sXak74lmSWGQ4Wwk+uEkpM0Za+KTc/1E6EVk6BIo916VS9tzVAQ6IinDPuPu+ODFlFb9/5gVHnOaY4Uw==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@posthog/core": "^1.39.6",
+        "@posthog/types": "^1.392.1",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.29.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.3.0"
+      }
+    },
+    "node_modules/posthog-js/node_modules/preact": {
+      "version": "10.29.4",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.4.tgz",
+      "integrity": "sha512-GMpwh9+NJ8tSmqwIaVyFRQkiKfBEzQ+k7r7tle4W+kaJ+7wJiB9hFz9BixAomMtenPPSBfM4bZhXozGxhf0uFQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/posthog-node": {
+      "version": "5.21.2",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.21.2.tgz",
+      "integrity": "sha512-Jehlu0KguL1LLyUczCt86OtA5INmeStK3zcgbv1BSyMcNxs0HP3GQogBrYhwhqHsk6JopiFFVpJyZEoXOUMhGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "1.10.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/posthog-node/node_modules/@posthog/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-Xk3JQ+cdychsvftrV3G9ZrN9W329lbyFW0pGJXFGKFQf8qr4upw2SgNg9BVorjSrfhoXZRnJGt/uNF4nGFBL5A==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
+      }
+    },
     "node_modules/preact": {
       "version": "10.24.3",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
@@ -7673,6 +7770,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -9395,6 +9498,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "next-auth": "^4.24.11",
     "next-themes": "^0.2.1",
     "openai": "^4.98.0",
+    "posthog-js": "^1.396.6",
+    "posthog-node": "^5.21.2",
     "react": "18.2.0",
     "react-day-picker": "^9.6.7",
     "react-dom": "18.2.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -432,3 +432,27 @@ model ParentMessage {
   @@index([threadId])
   @@index([senderId])
 }
+
+model AnalyticsEvent {
+  id         String   @id @default(cuid())
+  userId     String?
+  event      String
+  properties Json     @default("{}")
+  createdAt  DateTime @default(now())
+
+  @@index([event])
+  @@index([userId])
+  @@index([createdAt])
+}
+
+model AnalyticsError {
+  id        String   @id @default(cuid())
+  userId    String?
+  source    String
+  message   String
+  metadata  Json     @default("{}")
+  createdAt DateTime @default(now())
+
+  @@index([createdAt])
+  @@index([source])
+}

--- a/src/app/admin/founder/page.tsx
+++ b/src/app/admin/founder/page.tsx
@@ -157,6 +157,8 @@ export default function FounderDashboardPage() {
           <MetricCard label="Onboarding done" value={`${s.onboardingRate}%`} />
           <MetricCard label="Returning users" value={s.returningUsers} />
           <MetricCard label="Most used feature" value={s.mostUsedFeature} />
+          <MetricCard label="Avg events / DAU today" value={s.avgEventsPerActiveUserToday} />
+          <MetricCard label="Avg onboarding (sec)" value={s.avgOnboardingSeconds ?? "—"} />
         </section>
 
         <section className="grid grid-cols-2 md:grid-cols-4 gap-3">

--- a/src/app/admin/founder/page.tsx
+++ b/src/app/admin/founder/page.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { AppShell } from "@/components/layout/app-shell";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import type { FounderMetrics } from "@/lib/services/founder-metrics";
+import { format } from "date-fns";
+
+function MetricCard({ label, value }: { label: string; value: string | number }) {
+  return (
+    <Card className="rounded-2xl">
+      <CardContent className="p-4">
+        <p className="text-xs text-muted-foreground">{label}</p>
+        <p className="text-2xl font-bold mt-1">{value}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function BarChart({
+  title,
+  data,
+  labelKey,
+  valueKey,
+}: {
+  title: string;
+  data: Record<string, unknown>[];
+  labelKey: string;
+  valueKey: string;
+}) {
+  const max = Math.max(...data.map((d) => Number(d[valueKey]) || 0), 1);
+  return (
+    <Card className="rounded-2xl">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-semibold">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {data.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No data yet</p>
+        ) : (
+          data.map((row) => {
+            const label = String(row[labelKey]);
+            const value = Number(row[valueKey]) || 0;
+            return (
+              <div key={label} className="space-y-1">
+                <div className="flex justify-between text-xs">
+                  <span className="truncate pr-2">{label}</span>
+                  <span className="text-muted-foreground shrink-0">{value}</span>
+                </div>
+                <div className="h-2 rounded-full bg-muted overflow-hidden">
+                  <div
+                    className="h-full bg-primary rounded-full transition-all"
+                    style={{ width: `${Math.round((value / max) * 100)}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function InsightList({ title, items }: { title: string; items: { name: string; count: number }[] }) {
+  return (
+    <Card className="rounded-2xl">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-semibold">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {items.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No data yet</p>
+        ) : (
+          items.map((item) => (
+            <div key={item.name} className="flex items-center justify-between text-sm gap-2">
+              <span className="truncate">{item.name}</span>
+              <Badge variant="secondary" className="rounded-full shrink-0">{item.count}</Badge>
+            </div>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function FounderDashboardPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const [metrics, setMetrics] = useState<FounderMetrics | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (status === "unauthenticated") {
+      router.push("/auth/signin");
+      return;
+    }
+    if (status !== "authenticated") return;
+
+    fetch("/api/admin/founder/metrics")
+      .then(async (res) => {
+        if (res.status === 403) {
+          setError("Admin access only. Set FOUNDER_ADMIN_EMAILS in Vercel.");
+          return null;
+        }
+        if (!res.ok) throw new Error("Failed to load");
+        return res.json() as Promise<FounderMetrics>;
+      })
+      .then((data) => {
+        if (data) setMetrics(data);
+      })
+      .catch(() => setError("Could not load founder metrics."));
+  }, [status, router]);
+
+  if (status === "loading" || (!metrics && !error)) {
+    return (
+      <AppShell>
+        <div className="container max-w-5xl mx-auto p-6 text-sm text-muted-foreground">Loading founder dashboard…</div>
+      </AppShell>
+    );
+  }
+
+  if (error) {
+    return (
+      <AppShell>
+        <div className="container max-w-lg mx-auto p-6 text-center space-y-2">
+          <p className="text-destructive text-sm">{error}</p>
+          <p className="text-xs text-muted-foreground">Signed in as {session?.user?.email}</p>
+        </div>
+      </AppShell>
+    );
+  }
+
+  if (!metrics) return null;
+
+  const s = metrics.summary;
+
+  return (
+    <AppShell>
+      <div className="container max-w-5xl mx-auto p-4 pb-10 space-y-6">
+        <header className="space-y-1 pt-2">
+          <h1 className="text-xl font-bold">Founder Dashboard</h1>
+          <p className="text-xs text-muted-foreground">
+            Internal beta metrics · Updated {format(new Date(metrics.generatedAt), "d MMM yyyy HH:mm")}
+          </p>
+        </header>
+
+        <section className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <MetricCard label="Total users" value={s.totalUsers} />
+          <MetricCard label="New today" value={s.newUsersToday} />
+          <MetricCard label="Daily active" value={s.dailyActiveUsers} />
+          <MetricCard label="Weekly active" value={s.weeklyActiveUsers} />
+          <MetricCard label="Monthly active" value={s.monthlyActiveUsers} />
+          <MetricCard label="Onboarding done" value={`${s.onboardingRate}%`} />
+          <MetricCard label="Returning users" value={s.returningUsers} />
+          <MetricCard label="Most used feature" value={s.mostUsedFeature} />
+        </section>
+
+        <section className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <MetricCard label="MumBot questions" value={metrics.events.mumbot_question_asked ?? 0} />
+          <MetricCard label="Stories read" value={s.storiesRead} />
+          <MetricCard label="Meals viewed" value={s.mealsViewed} />
+          <MetricCard label="Activities started" value={s.activitiesStarted} />
+          <MetricCard label="Connect requests" value={s.connectRequests} />
+          <MetricCard label="Events created" value={s.eventsCreated} />
+          <MetricCard label="Parent check-ins" value={s.parentCheckins} />
+          <MetricCard label="Feedback" value={s.feedbackSubmitted} />
+        </section>
+
+        <section className="grid md:grid-cols-2 gap-4">
+          <BarChart
+            title="Daily active users (14 days)"
+            data={metrics.charts.dailyActiveUsers}
+            labelKey="day"
+            valueKey="count"
+          />
+          <BarChart
+            title="Daily signups (14 days)"
+            data={metrics.charts.weeklySignups}
+            labelKey="day"
+            valueKey="count"
+          />
+          <BarChart
+            title="Feature usage"
+            data={metrics.charts.featureUsage}
+            labelKey="feature"
+            valueKey="count"
+          />
+          <BarChart
+            title="Retention"
+            data={metrics.charts.retention}
+            labelKey="label"
+            valueKey="count"
+          />
+          <BarChart
+            title="MumBot usage"
+            data={metrics.charts.mumbotUsage}
+            labelKey="label"
+            valueKey="count"
+          />
+          <BarChart
+            title="Connect usage"
+            data={metrics.charts.connectUsage}
+            labelKey="label"
+            valueKey="count"
+          />
+        </section>
+
+        <section className="grid md:grid-cols-3 gap-4">
+          <InsightList title="Most popular parenting goals" items={metrics.insights.topParentingGoals} />
+          <InsightList title="Most common challenges" items={metrics.insights.topChallenges} />
+          <InsightList title="Most popular child age" items={metrics.insights.topChildAges} />
+        </section>
+
+        <section className="grid md:grid-cols-3 gap-4">
+          <InsightList title="Most opened stories" items={metrics.insights.topStories} />
+          <InsightList title="Most viewed meals" items={metrics.insights.topMeals} />
+          <InsightList title="Most viewed activities" items={metrics.insights.topActivities} />
+        </section>
+
+        <Card className="rounded-2xl">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-semibold">Recent errors</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {metrics.recentErrors.length === 0 ? (
+              <p className="text-xs text-muted-foreground">No logged errors</p>
+            ) : (
+              metrics.recentErrors.map((err) => (
+                <div key={err.id} className="text-xs border rounded-lg p-2 space-y-0.5">
+                  <div className="flex justify-between gap-2">
+                    <Badge variant="outline" className="rounded-full text-[10px]">{err.source}</Badge>
+                    <span className="text-muted-foreground">{format(new Date(err.createdAt), "d MMM HH:mm")}</span>
+                  </div>
+                  <p className="text-muted-foreground break-words">{err.message}</p>
+                </div>
+              ))
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </AppShell>
+  );
+}

--- a/src/app/api/admin/founder/metrics/route.ts
+++ b/src/app/api/admin/founder/metrics/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { isFounderAdmin } from "@/lib/admin";
+import { getFounderMetrics } from "@/lib/services/founder-metrics";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email || !isFounderAdmin(session.user.email)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const metrics = await getFounderMetrics();
+    return NextResponse.json(metrics);
+  } catch (error) {
+    console.error("Founder metrics error:", error);
+    return NextResponse.json({ error: "Failed to load metrics" }, { status: 500 });
+  }
+}

--- a/src/app/api/analytics/error/route.ts
+++ b/src/app/api/analytics/error/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { persistAnalyticsError } from "@/lib/analytics/persist";
+import { sanitizeProperties } from "@/lib/analytics/sanitize";
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+
+  try {
+    const body = (await request.json()) as {
+      source?: string;
+      message?: string;
+      metadata?: Record<string, unknown>;
+    };
+    if (!body.source || !body.message) {
+      return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+    }
+
+    await persistAnalyticsError(
+      body.source,
+      body.message,
+      session?.user?.id ?? null,
+      sanitizeProperties(body.metadata)
+    );
+
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ error: "Error log failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/analytics/track/route.ts
+++ b/src/app/api/analytics/track/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { persistAnalyticsEvent } from "@/lib/analytics/persist";
+import { sanitizeProperties } from "@/lib/analytics/sanitize";
+import type { AnalyticsEvent } from "@/lib/analytics/events";
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+
+  try {
+    const body = (await request.json()) as { event?: string; properties?: Record<string, unknown> };
+    if (!body.event?.trim()) {
+      return NextResponse.json({ error: "Missing event" }, { status: 400 });
+    }
+
+    await persistAnalyticsEvent(
+      body.event as AnalyticsEvent,
+      session?.user?.id ?? null,
+      sanitizeProperties(body.properties)
+    );
+
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ error: "Track failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/analytics/traits/route.ts
+++ b/src/app/api/analytics/traits/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { prisma } from "@/lib/db";
+
+/** Safe user traits for PostHog identify — no child names or private notes. */
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { createdAt: true, childAge: true, email: true },
+  });
+
+  if (!user) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    traits: {
+      email: user.email,
+      createdAt: user.createdAt.toISOString(),
+      childAge: user.childAge,
+    },
+  });
+}

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { hash } from 'bcryptjs';
 import { prisma } from '@/lib/db';
+import { captureServerEvent } from '@/lib/analytics/posthog-server';
+import { persistAnalyticsEvent } from '@/lib/analytics/persist';
 
 export async function POST(req: Request) {
   try {
@@ -52,6 +54,11 @@ export async function POST(req: Request) {
         password: hashedPassword,
       },
     });
+
+    await Promise.allSettled([
+      persistAnalyticsEvent('signup_completed', user.id, { method: 'email' }),
+      captureServerEvent(user.id, 'signup_completed', { method: 'email' }),
+    ]);
 
     // Remove password from response
     const { password: _, ...userWithoutPassword } = user;

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/db";
 import { getMumBotResponse } from "@/lib/services/mumbot";
+import { trackServerError } from "@/lib/analytics/server-errors";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -115,10 +116,17 @@ export async function POST(request: Request) {
     });
   } catch (error) {
     console.error("Chat API error:", error);
+    const session = await getServerSession(authOptions);
+    await trackServerError(
+      "openai_chat",
+      error,
+      session?.user?.id,
+      { provider: "openai" }
+    );
     const message =
       error instanceof Error && error.message.includes("API key")
         ? "MumBot could not reach OpenAI. Please check OPENAI_API_KEY in Vercel settings."
-        : "Internal server error";
+        : "Something went wrong. Please try again.";
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import { trackEvent } from '@/lib/analytics';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -35,6 +36,7 @@ export default function Register() {
         throw new Error(data.error || data.message || 'Registration failed');
       }
 
+      trackEvent('signup_completed', { method: 'email' });
       router.push('/auth/signin?registered=true');
     } catch (error) {
       setError(error instanceof Error ? error.message : 'Registration failed');

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Github, Mail } from 'lucide-react';
 import Link from 'next/link';
+import { trackEvent, trackClientError } from '@/lib/analytics';
 
 export default function SignIn() {
   const router = useRouter();
@@ -31,13 +32,16 @@ export default function SignIn() {
       });
 
       if (result?.error) {
-        setError(result.error);
+        trackClientError('auth_login', 'Failed login');
+        setError('Invalid email or password. Please try again.');
         return;
       }
 
-      router.push('/dashboard');
+      trackEvent('login', { method: 'credentials' });
+      router.push('/today');
       router.refresh();
-    } catch (error) {
+    } catch {
+      trackClientError('auth_login', 'Sign in error');
       setError('An error occurred during sign in');
     } finally {
       setIsLoading(false);

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -9,7 +9,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Github, Mail } from 'lucide-react';
 import Link from 'next/link';
-import { trackEvent, trackClientError } from '@/lib/analytics';
+import { trackClientError } from '@/lib/analytics';
 
 export default function SignIn() {
   const router = useRouter();
@@ -37,7 +37,6 @@ export default function SignIn() {
         return;
       }
 
-      trackEvent('login', { method: 'credentials' });
       router.push('/today');
       router.refresh();
     } catch {

--- a/src/app/connect/page.tsx
+++ b/src/app/connect/page.tsx
@@ -152,7 +152,7 @@ function ConnectContent() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ broadArea, timeWindow, interest, childAgeRange, note, isOpen }),
     });
-    trackEvent('connect_status_created');
+    trackEvent(myStatus ? 'available_today_updated' : 'available_today_created');
     toast.success(isOpen ? 'You\'re open to connect today!' : 'Status saved as private');
     setShowStatusForm(false);
     loadAvailable();
@@ -161,6 +161,7 @@ function ConnectContent() {
 
   const clearStatus = async () => {
     await fetch('/api/connect/status', { method: 'DELETE' });
+    trackEvent('available_today_closed');
     setMyStatus(null);
     loadAvailable();
     loadMy();
@@ -173,6 +174,7 @@ function ConnectContent() {
       body: JSON.stringify({ statusId }),
     });
     toast.success('Interest sent!');
+    trackEvent('connection_interest_sent');
     loadRequests();
   };
 
@@ -205,9 +207,10 @@ function ConnectContent() {
     const res = await fetch(`/api/connect/events/${eventId}/join`, { method: 'POST' });
     const data = await res.json();
     if (data.pending) {
+      trackEvent('event_join_requested');
       toast.success('Join request sent');
     } else if (data.joined) {
-      trackEvent('event_joined');
+      trackEvent('event_join_approved');
       toast.success('You joined the event!');
     }
     loadEvents();
@@ -215,11 +218,19 @@ function ConnectContent() {
   };
 
   const handleRequest = async (id: string, action: 'accept' | 'decline') => {
+    const req = requests.find((r) => r.id === id);
     await fetch(`/api/connect/requests/${id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action }),
     });
+    if (action === 'accept') {
+      if (req?.requestType === 'EVENT_JOIN') trackEvent('event_join_approved');
+      else trackEvent('connection_request_accepted');
+    } else {
+      if (req?.requestType === 'EVENT_JOIN') trackEvent('event_join_declined');
+      else trackEvent('connection_request_declined');
+    }
     loadRequests();
     loadMy();
   };

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { trackClientError } from '@/lib/analytics';
 
 export default function Error({
   error,
@@ -10,7 +11,7 @@ export default function Error({
   reset: () => void;
 }) {
   useEffect(() => {
-    // Log the error to an error reporting service
+    trackClientError('app_crash', error.message, { digest: error.digest });
     console.error(error);
   }, [error]);
 
@@ -18,6 +19,7 @@ export default function Error({
     <div className="flex min-h-screen flex-col items-center justify-center">
       <div className="text-center">
         <h2 className="text-2xl font-bold mb-4">Something went wrong!</h2>
+        <p className="text-sm text-muted-foreground mb-4">We&apos;ve logged this issue. Please try again.</p>
         <button
           onClick={() => reset()}
           className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
@@ -27,4 +29,4 @@ export default function Error({
       </div>
     </div>
   );
-} 
+}

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -101,10 +101,11 @@ export default function OnboardingPage() {
 
   const handleFinish = async () => {
     await saveProgress(true);
-    trackEvent('signup_completed');
-    if (childNickname || childAge) trackEvent('child_profile_created');
-    if (parentingGoals.length) trackEvent('parenting_goals_selected');
-    if (currentChallenges.length) trackEvent('current_challenges_selected');
+    trackEvent('onboarding_completed');
+    if (childAge) trackEvent('child_profile_created');
+    if (parentingGoals.length) trackEvent('parenting_goals_selected', { count: parentingGoals.length });
+    if (currentChallenges.length) trackEvent('current_challenges_selected', { count: currentChallenges.length });
+    if (broadArea || location) trackEvent('connect_area_selected');
     router.push('/today');
   };
 
@@ -260,7 +261,7 @@ export default function OnboardingPage() {
               </div>
               <div className="flex gap-2">
                 <Button variant="outline" className="rounded-xl" onClick={() => setStep('challenges')}><ArrowLeft className="h-4 w-4" /></Button>
-                <Button variant="ghost" className="rounded-xl" onClick={() => setStep('ready')}>Skip</Button>
+                <Button variant="ghost" className="rounded-xl" onClick={() => { trackEvent('onboarding_skipped', { step: 'area' }); setStep('ready'); }}>Skip</Button>
                 <Button className="flex-1 rounded-xl" onClick={() => setStep('ready')} disabled={!broadArea.trim()}>
                   Continue
                 </Button>

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -39,6 +39,12 @@ export default function OnboardingPage() {
   const [location, setLocation] = useState('');
 
   useEffect(() => {
+    if (status === 'authenticated' && !localStorage.getItem('parenfy_onboarding_start')) {
+      localStorage.setItem('parenfy_onboarding_start', String(Date.now()));
+    }
+  }, [status]);
+
+  useEffect(() => {
     if (status === 'authenticated') {
       fetch('/api/onboarding')
         .then((r) => r.json())
@@ -101,7 +107,11 @@ export default function OnboardingPage() {
 
   const handleFinish = async () => {
     await saveProgress(true);
-    trackEvent('onboarding_completed');
+    const startRaw = localStorage.getItem("parenfy_onboarding_start");
+    const durationSeconds = startRaw
+      ? Math.round((Date.now() - parseInt(startRaw, 10)) / 1000)
+      : undefined;
+    trackEvent("onboarding_completed", durationSeconds ? { duration_seconds: durationSeconds } : undefined);
     if (childAge) trackEvent('child_profile_created');
     if (parentingGoals.length) trackEvent('parenting_goals_selected', { count: parentingGoals.length });
     if (currentChallenges.length) trackEvent('current_challenges_selected', { count: currentChallenges.length });

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -19,6 +19,7 @@ import {
   MAX_CURRENT_CHALLENGES,
 } from '@/lib/constants';
 import { cn } from '@/lib/utils';
+import { trackEvent } from '@/lib/analytics';
 
 interface Profile {
   name: string;
@@ -174,6 +175,9 @@ function ProfileContent() {
       const data = await res.json();
       setProfile(data.profile);
       setEditing(false);
+      if (childAge || childInterests) {
+        trackEvent('child_profile_updated', { has_age: Boolean(childAge), has_interests: Boolean(childInterests) });
+      }
     } finally {
       setSaving(false);
     }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -2,20 +2,23 @@
 
 import { SessionProvider } from 'next-auth/react';
 import { ThemeProvider } from '@/components/theme/theme-provider';
+import { PostHogProvider } from '@/components/providers/posthog-provider';
 import { Toaster } from 'sonner';
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <SessionProvider>
-      <ThemeProvider
-        attribute="class"
-        defaultTheme="system"
-        enableSystem
-        disableTransitionOnChange
-      >
-        {children}
-        <Toaster richColors position="top-center" />
-      </ThemeProvider>
+      <PostHogProvider>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          {children}
+          <Toaster richColors position="top-center" />
+        </ThemeProvider>
+      </PostHogProvider>
     </SessionProvider>
   );
 } 

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -264,7 +264,17 @@ export default function TodayPage() {
     trackEvent(tryAnother ? 'meal_from_fridge_retry' : 'meal_from_fridge');
   };
 
-  const closeDetail = () => setActiveDetail(null);
+  const closeDetail = () => {
+    const brief = data?.brief;
+    if (activeDetail === 'story' && brief) {
+      trackEvent('story_completed', { title: brief.bedtimeStory.title });
+    }
+    if (activeDetail === 'language' && brief) {
+      const lang = getLanguageItem(brief.development);
+      trackEvent('language_activity_completed', { domain: lang.domain });
+    }
+    setActiveDetail(null);
+  };
 
   if (status === 'loading' || loading) {
     return (

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -161,11 +161,39 @@ export default function TodayPage() {
     if (json.brief) {
       setData((prev) => (prev ? { ...prev, brief: json.brief } : prev));
     }
+    if (action === 'save-recipe') {
+      trackEvent('meal_saved', { title: json.brief?.recipe?.subtitle ?? data?.brief?.recipe?.subtitle });
+    }
+    if (action === 'save-story') {
+      trackEvent('story_saved', { title: json.brief?.bedtimeStory?.title ?? data?.brief?.bedtimeStory?.title });
+    }
+    if (action === 'save-activity') {
+      trackEvent('activity_completed', { title: json.brief?.play?.title ?? data?.brief?.play?.title });
+    }
     return json;
   };
 
+  useEffect(() => {
+    const brief = data?.brief;
+    if (!brief || !activeDetail) return;
+    if (activeDetail === 'meal') {
+      trackEvent('meal_viewed', { title: brief.recipe.subtitle });
+    }
+    if (activeDetail === 'story') {
+      trackEvent('story_started', { title: brief.bedtimeStory.title });
+    }
+    if (activeDetail === 'activity') {
+      trackEvent('activity_started', { title: brief.play.title });
+    }
+    if (activeDetail === 'language') {
+      const lang = brief.development.find((d) => /language|speech/i.test(d.domain)) ?? brief.development[0];
+      if (lang) trackEvent('language_activity_started', { domain: lang.domain });
+    }
+  }, [activeDetail, data?.brief]);
+
   const rotate = async (section: RotateSection) => {
     setRotating(section);
+    trackEvent('today_refresh_clicked', { section });
     const toastId = toast.loading('Finding another idea…');
     try {
       const res = await fetch('/api/today/rotate', {
@@ -178,17 +206,25 @@ export default function TodayPage() {
       if (json.brief) {
         setData((prev) => (prev ? { ...prev, brief: json.brief } : prev));
       }
+      if (section === 'recipe') {
+        trackEvent('meal_rotated', { title: json.brief?.recipe?.subtitle });
+        invalidateTodayRecipeIllustrationCache();
+        prefetchTodayRecipeIllustration().catch(() => {});
+        warmTodayRecipeIllustration().catch(() => {});
+      }
+      if (section === 'play') {
+        trackEvent('activity_rotated', { title: json.brief?.play?.title });
+      }
       if (section === 'story') {
+        trackEvent('story_rotated', { title: json.brief?.bedtimeStory?.title });
         invalidateTodayStoryAudioCache();
         invalidateTodayStoryIllustrationCache();
         prefetchTodayStoryAudio().catch(() => {});
         prefetchTodayStoryIllustration().catch(() => {});
         warmTodayStoryIllustration().catch(() => {});
       }
-      if (section === 'recipe') {
-        invalidateTodayRecipeIllustrationCache();
-        prefetchTodayRecipeIllustration().catch(() => {});
-        warmTodayRecipeIllustration().catch(() => {});
+      if (section === 'language') {
+        trackEvent('language_activity_started');
       }
       toast.success('Here\'s another idea!', { id: toastId });
     } catch {
@@ -342,7 +378,7 @@ export default function TodayPage() {
                 preview={truncateWords(brief.recipe.whyThisMeal || brief.recipe.title, 15)}
                 ctaLabel="View Meal"
                 onOpen={() => {
-                  trackEvent('meal_clicked');
+                  trackEvent('meal_card_opened', { title: brief.recipe.subtitle });
                   setActiveDetail('meal');
                 }}
                 onRefresh={() => rotate('recipe')}
@@ -355,7 +391,7 @@ export default function TodayPage() {
                 preview={truncateWords(brief.play.instructions[0] || 'A fun age-appropriate activity.', 15)}
                 ctaLabel="Start Activity"
                 onOpen={() => {
-                  trackEvent('activity_clicked');
+                  trackEvent('activity_card_opened', { title: brief.play.title });
                   setActiveDetail('activity');
                 }}
                 onRefresh={() => rotate('play')}
@@ -368,7 +404,7 @@ export default function TodayPage() {
                 preview={truncateWords(brief.bedtimeStory.moral || 'A bedtime tale for tonight.', 15)}
                 ctaLabel="Read Story"
                 onOpen={() => {
-                  trackEvent('story_clicked');
+                  trackEvent('story_card_opened', { title: brief.bedtimeStory.title });
                   setActiveDetail('story');
                 }}
                 onRefresh={() => rotate('story')}
@@ -381,7 +417,10 @@ export default function TodayPage() {
                   title={languageItem.domain}
                   preview={truncateWords(languageItem.tryToday || languageItem.insight, 15)}
                   ctaLabel="Try Words"
-                  onOpen={() => setActiveDetail('language')}
+                  onOpen={() => {
+                    trackEvent('language_card_opened', { domain: languageItem.domain });
+                    setActiveDetail('language');
+                  }}
                   onRefresh={() => rotate('language')}
                   refreshing={rotating === 'language'}
                 />

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -12,7 +12,7 @@ import { messagesAtom, type ChatMessage as ChatMessageType } from '@/lib/store/c
 import { generateWelcomeMessage } from '@/lib/mumbot-messages';
 import { Button } from '@/components/ui/button';
 import { useSession } from 'next-auth/react';
-import { trackEvent } from '@/lib/analytics';
+import { trackEvent, trackClientError } from '@/lib/analytics';
 
 interface SuggestedMemory {
   content: string;
@@ -103,7 +103,11 @@ export function ChatInterface() {
       setIsLoading(true);
       setPendingMemory(null);
       setShowActions(false);
-      trackEvent('mumbot_question');
+      trackEvent('mumbot_question_asked');
+      const lower = content.toLowerCase();
+      if (/meal|recipe|food|dinner|lunch/.test(lower)) trackEvent('mumbot_recipe_generated');
+      if (/story|bedtime|tale/.test(lower)) trackEvent('mumbot_story_generated');
+      if (/activity|play|game/.test(lower)) trackEvent('mumbot_activity_generated');
 
       const userMessage: ChatMessageType = {
         id: Date.now().toString(),
@@ -156,6 +160,7 @@ export function ChatInterface() {
         setPendingMemory(data.suggestedMemory);
       }
     } catch (error) {
+      trackClientError('mumbot_chat', error instanceof Error ? error.message : 'Chat failed');
       const errorMessage: ChatMessageType = {
         id: (Date.now() + 1).toString(),
         content: error instanceof Error ? error.message : 'I apologize, but I encountered an error. Please try again later.',
@@ -228,7 +233,10 @@ export function ChatInterface() {
                   size="sm"
                   variant="outline"
                   className="rounded-full text-xs h-8"
-                  onClick={() => handleSendMessage(rest.prompt)}
+                  onClick={() => {
+                    trackEvent('mumbot_followup_clicked', { action: id });
+                    void handleSendMessage(rest.prompt);
+                  }}
                 >
                   <Icon className="h-3.5 w-3.5 mr-1" /> {label}
                 </Button>

--- a/src/components/feedback/beta-feedback-button.tsx
+++ b/src/components/feedback/beta-feedback-button.tsx
@@ -23,7 +23,9 @@ export function BetaFeedbackButton() {
     try {
       // TODO: Persist feedback via Supabase, Formspree, or Resend in Vercel production
       await new Promise((r) => setTimeout(r, 400));
-      trackEvent("feedback_submitted", { rating, recommend });
+      trackEvent("feedback_submitted", { rating, has_recommend: Boolean(recommend.trim()) });
+      if (rating !== null && rating >= 4) trackEvent("mumbot_feedback_positive", { rating });
+      if (rating !== null && rating <= 2) trackEvent("mumbot_feedback_negative", { rating });
       toast.success("Thank you — your feedback helps us improve!");
       setOpen(false);
       setEnjoyed("");
@@ -65,6 +67,7 @@ export function BetaFeedbackButton() {
                   onChange={(e) => setEnjoyed(e.target.value)}
                   placeholder="What felt helpful or delightful..."
                   className="mt-1"
+                  data-ph-mask
                   rows={2}
                 />
               </div>
@@ -76,6 +79,7 @@ export function BetaFeedbackButton() {
                   onChange={(e) => setConfused(e.target.value)}
                   placeholder="Anything unclear..."
                   className="mt-1"
+                  data-ph-mask
                   rows={2}
                 />
               </div>
@@ -87,6 +91,7 @@ export function BetaFeedbackButton() {
                   onChange={(e) => setImprove(e.target.value)}
                   placeholder="One thing we could do better..."
                   className="mt-1"
+                  data-ph-mask
                   rows={2}
                 />
               </div>
@@ -98,6 +103,7 @@ export function BetaFeedbackButton() {
                   onChange={(e) => setRecommend(e.target.value)}
                   placeholder="Yes / Maybe / Not yet — and why..."
                   className="mt-1"
+                  data-ph-mask
                   rows={2}
                 />
               </div>

--- a/src/components/home/parent-checkin-card.tsx
+++ b/src/components/home/parent-checkin-card.tsx
@@ -7,6 +7,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { HeartHandshake, ChevronDown, ChevronUp } from 'lucide-react';
 import { toast } from 'sonner';
+import { trackEvent } from '@/lib/analytics';
 
 interface ParentCheckInCardProps {
   onSubmit: (data: { feeling: string; win: string; challenge: string }) => Promise<{ encouragement?: string }>;
@@ -25,6 +26,7 @@ export function ParentCheckInCard({ onSubmit }: ParentCheckInCardProps) {
       toast.error('How are you feeling today?');
       return;
     }
+    trackEvent('parent_checkin_started');
     setSubmitting(true);
     try {
       const result = await onSubmit({
@@ -32,6 +34,7 @@ export function ParentCheckInCard({ onSubmit }: ParentCheckInCardProps) {
         win: win.trim(),
         challenge: challenge.trim(),
       });
+      trackEvent('parent_checkin_completed');
       setEncouragement(result.encouragement ?? "You're doing a wonderful job. Small steps count.");
       setFeeling('');
       setWin('');
@@ -73,6 +76,7 @@ export function ParentCheckInCard({ onSubmit }: ParentCheckInCardProps) {
               onChange={(e) => setFeeling(e.target.value)}
               placeholder="Tired but hopeful..."
               className="mt-1 rounded-xl"
+              data-ph-mask
             />
           </div>
           <div>
@@ -83,6 +87,7 @@ export function ParentCheckInCard({ onSubmit }: ParentCheckInCardProps) {
               onChange={(e) => setWin(e.target.value)}
               placeholder="We got out for a walk..."
               className="mt-1 rounded-xl"
+              data-ph-mask
             />
           </div>
           <div>
@@ -94,6 +99,7 @@ export function ParentCheckInCard({ onSubmit }: ParentCheckInCardProps) {
               placeholder="Bedtime was tough..."
               className="mt-1 rounded-xl resize-none"
               rows={2}
+              data-ph-mask
             />
           </div>
           <Button

--- a/src/components/providers/posthog-provider.tsx
+++ b/src/components/providers/posthog-provider.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSession } from "next-auth/react";
+import { usePathname } from "next/navigation";
+import { initPostHogClient, getPostHogClient } from "@/lib/analytics/posthog-client";
+import { identifyUser, resetAnalyticsIdentity, trackFeatureUsed, trackEvent } from "@/lib/analytics/track";
+import { PATH_FEATURE_MAP } from "@/lib/analytics/events";
+
+type ProfileTraits = {
+  email?: string | null;
+  createdAt?: string;
+  childAge?: string | null;
+};
+
+/** Initialise PostHog, identify users, and track feature usage by route. */
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  const { data: session, status } = useSession();
+  const pathname = usePathname();
+  const lastPath = useRef<string | null>(null);
+  const identified = useRef<string | null>(null);
+
+  useEffect(() => {
+    initPostHogClient();
+  }, []);
+
+  useEffect(() => {
+    if (status !== "authenticated" || !session?.user?.id) {
+      if (status === "unauthenticated" && identified.current) {
+        resetAnalyticsIdentity();
+        identified.current = null;
+      }
+      return;
+    }
+
+    if (identified.current === session.user.id) return;
+
+    void fetch("/api/analytics/traits")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: { traits?: ProfileTraits } | null) => {
+        const traits = data?.traits;
+        identifyUser(session.user!.id!, {
+          email: session.user?.email,
+          signup_date: traits?.createdAt,
+          child_age: traits?.childAge ?? undefined,
+          subscription_type: "free",
+        });
+        identified.current = session.user!.id!;
+      })
+      .catch(() => {
+        identifyUser(session.user!.id!, {
+          email: session.user?.email,
+          subscription_type: "free",
+        });
+        identified.current = session.user!.id!;
+      });
+  }, [status, session?.user?.id, session?.user?.email]);
+
+  useEffect(() => {
+    if (!pathname || pathname === lastPath.current) return;
+    lastPath.current = pathname;
+
+    getPostHogClient()?.capture("$pageview", { $current_url: pathname });
+
+    const base = pathname.split("?")[0];
+    const feature = PATH_FEATURE_MAP[base];
+    if (feature) {
+      trackFeatureUsed(feature, base);
+    }
+
+    if (base === "/mumbot") {
+      trackEvent("mumbot_opened");
+    }
+    if (base === "/connect") {
+      trackEvent("connect_page_opened");
+    }
+  }, [pathname]);
+
+  return <>{children}</>;
+}

--- a/src/components/today/today-cards.tsx
+++ b/src/components/today/today-cards.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { trackEvent } from '@/lib/analytics';
 
 interface TodayCompactCardProps {
   emoji: string;
@@ -97,7 +98,12 @@ export function TodayFocusCard({ type, title, tip, onAskMumbot }: TodayFocusCard
       <Button
         size="sm"
         className="rounded-full shrink-0 h-9 px-3 text-xs touch-target"
-        onClick={onAskMumbot}
+        onClick={() => {
+          if (/milestone|development/i.test(title)) {
+            trackEvent('milestone_card_opened', { title });
+          }
+          onAskMumbot();
+        }}
       >
         {type === 'goal' ? 'Ask MumBot' : 'Get help'}
       </Button>

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,0 +1,16 @@
+/** Admin access for founder dashboard — set FOUNDER_ADMIN_EMAILS in Vercel (comma-separated). */
+export function getFounderAdminEmails(): string[] {
+  const raw = process.env.FOUNDER_ADMIN_EMAILS?.trim();
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function isFounderAdmin(email?: string | null): boolean {
+  if (!email) return false;
+  const admins = getFounderAdminEmails();
+  if (admins.length === 0) return false;
+  return admins.includes(email.toLowerCase());
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,58 +1,7 @@
 /**
- * Analytics event tracking placeholders for Parenfy beta.
- * TODO: Wire to PostHog, Google Analytics, or Supabase events in Vercel production.
+ * Product analytics — PostHog + internal persistence for founder insights.
+ * Configure NEXT_PUBLIC_POSTHOG_KEY and NEXT_PUBLIC_POSTHOG_HOST in Vercel.
  */
-
-export type AnalyticsEvent =
-  | "signup_completed"
-  | "child_profile_created"
-  | "parenting_goals_selected"
-  | "current_challenges_selected"
-  | "today_dashboard_viewed"
-  | "mumbot_question"
-  | "meal_clicked"
-  | "meal_from_fridge"
-  | "meal_from_fridge_retry"
-  | "story_clicked"
-  | "activity_clicked"
-  | "connect_status_created"
-  | "event_created"
-  | "event_joined"
-  | "parent_checkin_completed"
-  | "feedback_submitted"
-  | "day2_return"
-  | "day7_return";
-
-export function trackEvent(event: AnalyticsEvent, properties?: Record<string, unknown>): void {
-  if (typeof window === "undefined") return;
-  // TODO: Replace with PostHog / Google Analytics / Supabase events
-  if (process.env.NODE_ENV === "development") {
-    console.debug("[analytics]", event, properties);
-  }
-}
-
-const RETURN_KEY = "parenfy_first_visit";
-
-/** Track day-2 and day-7 return on Today dashboard load. */
-export function trackReturnVisit(): void {
-  if (typeof window === "undefined") return;
-  const raw = localStorage.getItem(RETURN_KEY);
-  const now = Date.now();
-  if (!raw) {
-    localStorage.setItem(RETURN_KEY, String(now));
-    return;
-  }
-  const firstVisit = parseInt(raw, 10);
-  if (Number.isNaN(firstVisit)) return;
-  const days = Math.floor((now - firstVisit) / (1000 * 60 * 60 * 24));
-  const day2Key = "parenfy_day2_tracked";
-  const day7Key = "parenfy_day7_tracked";
-  if (days >= 1 && days < 7 && !localStorage.getItem(day2Key)) {
-    trackEvent("day2_return");
-    localStorage.setItem(day2Key, "1");
-  }
-  if (days >= 7 && !localStorage.getItem(day7Key)) {
-    trackEvent("day7_return");
-    localStorage.setItem(day7Key, "1");
-  }
-}
+export type { AnalyticsEvent, FeatureName } from "@/lib/analytics/events";
+export { trackEvent, identifyUser, resetAnalyticsIdentity, trackFeatureUsed, trackClientError } from "@/lib/analytics/track";
+export { trackReturnVisit } from "@/lib/analytics/retention";

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -1,0 +1,104 @@
+/** PostHog product analytics event names — keep in sync with founder dashboard queries. */
+export type AnalyticsEvent =
+  // Authentication
+  | "signup_completed"
+  | "login"
+  | "logout"
+  | "account_deleted"
+  // Onboarding
+  | "child_profile_created"
+  | "child_profile_updated"
+  | "parenting_goals_selected"
+  | "current_challenges_selected"
+  | "connect_area_selected"
+  | "onboarding_completed"
+  | "onboarding_skipped"
+  // Today dashboard
+  | "today_dashboard_viewed"
+  | "meal_card_opened"
+  | "story_card_opened"
+  | "activity_card_opened"
+  | "language_card_opened"
+  | "milestone_card_opened"
+  | "today_refresh_clicked"
+  // MumBot
+  | "mumbot_opened"
+  | "mumbot_question_asked"
+  | "mumbot_followup_clicked"
+  | "mumbot_story_generated"
+  | "mumbot_recipe_generated"
+  | "mumbot_activity_generated"
+  | "mumbot_feedback_positive"
+  | "mumbot_feedback_negative"
+  // Stories
+  | "story_started"
+  | "story_completed"
+  | "story_saved"
+  | "story_rotated"
+  // Meals
+  | "meal_viewed"
+  | "meal_saved"
+  | "meal_rotated"
+  | "meal_from_fridge"
+  | "meal_from_fridge_retry"
+  // Activities
+  | "activity_started"
+  | "activity_completed"
+  | "activity_rotated"
+  // Language
+  | "language_activity_started"
+  | "language_activity_completed"
+  // Connect
+  | "available_today_created"
+  | "available_today_updated"
+  | "available_today_closed"
+  | "event_created"
+  | "event_updated"
+  | "event_join_requested"
+  | "event_join_approved"
+  | "event_join_declined"
+  | "connection_interest_sent"
+  | "connection_request_accepted"
+  | "connection_request_declined"
+  | "connect_page_opened"
+  // Parent check-in
+  | "parent_checkin_started"
+  | "parent_checkin_completed"
+  // Retention
+  | "day_1_return"
+  | "day_3_return"
+  | "day_7_return"
+  | "day_30_return"
+  | "weekly_active_user"
+  | "monthly_active_user"
+  // Feature usage (page / section)
+  | "feature_used"
+  // Feedback & errors
+  | "feedback_submitted"
+  | "app_error";
+
+export type FeatureName =
+  | "Today"
+  | "MumBot"
+  | "Connect"
+  | "Stories"
+  | "Meals"
+  | "Activities"
+  | "Language"
+  | "Milestones"
+  | "Parent Check-in"
+  | "Profile"
+  | "Settings"
+  | "Saved"
+  | "More";
+
+export const PATH_FEATURE_MAP: Record<string, FeatureName> = {
+  "/today": "Today",
+  "/mumbot": "MumBot",
+  "/connect": "Connect",
+  "/saved": "Saved",
+  "/profile": "Profile",
+  "/more": "More",
+  "/onboarding": "Settings",
+  "/home": "Today",
+};

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -101,4 +101,7 @@ export const PATH_FEATURE_MAP: Record<string, FeatureName> = {
   "/more": "More",
   "/onboarding": "Settings",
   "/home": "Today",
+  "/memory": "Milestones",
+  "/activities": "Activities",
+  "/chat": "MumBot",
 };

--- a/src/lib/analytics/persist.ts
+++ b/src/lib/analytics/persist.ts
@@ -1,0 +1,42 @@
+import { prisma } from "@/lib/db";
+import { sanitizeProperties } from "@/lib/analytics/sanitize";
+import type { AnalyticsEvent } from "@/lib/analytics/events";
+
+/** Persist sanitized events for founder dashboard (async, non-blocking). */
+export async function persistAnalyticsEvent(
+  event: AnalyticsEvent | string,
+  userId?: string | null,
+  properties?: Record<string, unknown>
+): Promise<void> {
+  try {
+    await prisma.analyticsEvent.create({
+      data: {
+        userId: userId ?? null,
+        event,
+        properties: (sanitizeProperties(properties) ?? {}) as object,
+      },
+    });
+  } catch (err) {
+    console.warn("[analytics] persist failed:", err);
+  }
+}
+
+export async function persistAnalyticsError(
+  source: string,
+  message: string,
+  userId?: string | null,
+  metadata?: Record<string, unknown>
+): Promise<void> {
+  try {
+    await prisma.analyticsError.create({
+      data: {
+        userId: userId ?? null,
+        source,
+        message: message.slice(0, 500),
+        metadata: (sanitizeProperties(metadata) ?? {}) as object,
+      },
+    });
+  } catch (err) {
+    console.warn("[analytics] error persist failed:", err);
+  }
+}

--- a/src/lib/analytics/posthog-client.ts
+++ b/src/lib/analytics/posthog-client.ts
@@ -1,0 +1,58 @@
+import type posthogJs from "posthog-js";
+
+let posthog: typeof posthogJs | null = null;
+let initialized = false;
+
+/** PostHog project key — set NEXT_PUBLIC_POSTHOG_KEY in Vercel. Never hardcode keys. */
+export function getPostHogKey(): string | undefined {
+  return process.env.NEXT_PUBLIC_POSTHOG_KEY?.trim() || undefined;
+}
+
+/** PostHog host — defaults to US cloud; use NEXT_PUBLIC_POSTHOG_HOST for EU self-hosted. */
+export function getPostHogHost(): string {
+  return process.env.NEXT_PUBLIC_POSTHOG_HOST?.trim() || "https://us.i.posthog.com";
+}
+
+export function isPostHogEnabled(): boolean {
+  return Boolean(getPostHogKey());
+}
+
+export function initPostHogClient(): typeof posthogJs | null {
+  if (typeof window === "undefined") return null;
+  const key = getPostHogKey();
+  if (!key) return null;
+
+  if (!posthog) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    posthog = require("posthog-js").default as typeof posthogJs;
+  }
+
+  if (initialized) return posthog;
+
+  posthog.init(key, {
+    api_host: getPostHogHost(),
+    person_profiles: "identified_only",
+    capture_pageview: false,
+    capture_pageleave: true,
+    persistence: "localStorage+cookie",
+    autocapture: false,
+    disable_session_recording: false,
+    session_recording: {
+      maskAllInputs: true,
+      maskTextSelector: "[data-ph-mask], [data-sensitive], textarea, input[type='password']",
+    },
+    loaded: (client) => {
+      if (process.env.NODE_ENV === "development") {
+        client.debug(false);
+      }
+    },
+  });
+
+  initialized = true;
+  return posthog;
+}
+
+export function getPostHogClient(): typeof posthogJs | null {
+  if (!initialized) return initPostHogClient();
+  return posthog;
+}

--- a/src/lib/analytics/posthog-server.ts
+++ b/src/lib/analytics/posthog-server.ts
@@ -1,0 +1,49 @@
+import { PostHog } from "posthog-node";
+import { getPostHogHost, getPostHogKey } from "@/lib/analytics/posthog-client";
+import { sanitizeProperties } from "@/lib/analytics/sanitize";
+import type { AnalyticsEvent } from "@/lib/analytics/events";
+
+let serverClient: PostHog | null = null;
+
+/** Server-side PostHog — uses POSTHOG_KEY or NEXT_PUBLIC_POSTHOG_KEY. Never expose server key to client. */
+function getServerKey(): string | undefined {
+  return (
+    process.env.POSTHOG_KEY?.trim() ||
+    process.env.NEXT_PUBLIC_POSTHOG_KEY?.trim() ||
+    undefined
+  );
+}
+
+export function getPostHogServer(): PostHog | null {
+  const key = getServerKey();
+  if (!key) return null;
+  if (!serverClient) {
+    serverClient = new PostHog(key, {
+      host: getPostHogHost(),
+      flushAt: 10,
+      flushInterval: 5000,
+    });
+  }
+  return serverClient;
+}
+
+export async function captureServerEvent(
+  distinctId: string,
+  event: AnalyticsEvent | string,
+  properties?: Record<string, unknown>
+): Promise<void> {
+  const client = getPostHogServer();
+  if (!client) return;
+  client.capture({
+    distinctId,
+    event,
+    properties: sanitizeProperties(properties),
+  });
+}
+
+export async function shutdownPostHogServer(): Promise<void> {
+  if (serverClient) {
+    await serverClient.shutdown();
+    serverClient = null;
+  }
+}

--- a/src/lib/analytics/retention.ts
+++ b/src/lib/analytics/retention.ts
@@ -1,0 +1,56 @@
+import { trackEvent } from "@/lib/analytics/track";
+
+const FIRST_VISIT_KEY = "parenfy_first_visit";
+const WEEK_KEY = "parenfy_wau_week";
+const MONTH_KEY = "parenfy_mau_month";
+
+function weekId(d = new Date()): string {
+  const start = new Date(d);
+  start.setHours(0, 0, 0, 0);
+  start.setDate(start.getDate() - start.getDay());
+  return start.toISOString().slice(0, 10);
+}
+
+function monthId(d = new Date()): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+/** Track retention milestones on active session (Today dashboard or app open). */
+export function trackReturnVisit(): void {
+  if (typeof window === "undefined") return;
+
+  const now = Date.now();
+  const raw = localStorage.getItem(FIRST_VISIT_KEY);
+  if (!raw) {
+    localStorage.setItem(FIRST_VISIT_KEY, String(now));
+    return;
+  }
+
+  const firstVisit = parseInt(raw, 10);
+  if (Number.isNaN(firstVisit)) return;
+
+  const days = Math.floor((now - firstVisit) / (1000 * 60 * 60 * 24));
+
+  const mark = (key: string, event: "day_1_return" | "day_3_return" | "day_7_return" | "day_30_return") => {
+    if (localStorage.getItem(key)) return;
+    trackEvent(event, { days_since_signup: days });
+    localStorage.setItem(key, "1");
+  };
+
+  if (days >= 1) mark("parenfy_day1_tracked", "day_1_return");
+  if (days >= 3) mark("parenfy_day3_tracked", "day_3_return");
+  if (days >= 7) mark("parenfy_day7_tracked", "day_7_return");
+  if (days >= 30) mark("parenfy_day30_tracked", "day_30_return");
+
+  const wk = weekId();
+  if (localStorage.getItem(WEEK_KEY) !== wk) {
+    trackEvent("weekly_active_user", { week: wk });
+    localStorage.setItem(WEEK_KEY, wk);
+  }
+
+  const mo = monthId();
+  if (localStorage.getItem(MONTH_KEY) !== mo) {
+    trackEvent("monthly_active_user", { month: mo });
+    localStorage.setItem(MONTH_KEY, mo);
+  }
+}

--- a/src/lib/analytics/sanitize.ts
+++ b/src/lib/analytics/sanitize.ts
@@ -1,0 +1,58 @@
+const SENSITIVE_KEYS = new Set([
+  "password",
+  "token",
+  "access_token",
+  "refresh_token",
+  "childnickname",
+  "child_nickname",
+  "childname",
+  "child_name",
+  "note",
+  "notes",
+  "content",
+  "message",
+  "messages",
+  "story",
+  "conversation",
+  "feeling",
+  "win",
+  "challenge",
+  "routineNotes",
+  "developmentNotes",
+  "bio",
+  "exactLocation",
+  "authorization",
+  "cookie",
+  "session",
+]);
+
+const SENSITIVE_PATTERN =
+  /password|token|secret|authorization|bearer|child.?name|nickname|private.?note|conversation|message.?content/i;
+
+function isSensitiveKey(key: string): boolean {
+  const normalized = key.toLowerCase().replace(/[_-]/g, "");
+  return SENSITIVE_KEYS.has(normalized) || SENSITIVE_PATTERN.test(key);
+}
+
+/** Strip PII before sending analytics payloads (GDPR-safe). */
+export function sanitizeProperties(
+  properties?: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  if (!properties) return undefined;
+
+  const clean: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(properties)) {
+    if (isSensitiveKey(key)) continue;
+    if (typeof value === "string" && value.length > 500) {
+      clean[key] = "[truncated]";
+      continue;
+    }
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      const nested = sanitizeProperties(value as Record<string, unknown>);
+      if (nested && Object.keys(nested).length > 0) clean[key] = nested;
+      continue;
+    }
+    clean[key] = value;
+  }
+  return Object.keys(clean).length > 0 ? clean : undefined;
+}

--- a/src/lib/analytics/server-errors.ts
+++ b/src/lib/analytics/server-errors.ts
@@ -1,0 +1,23 @@
+import { captureServerEvent } from "@/lib/analytics/posthog-server";
+import { persistAnalyticsError } from "@/lib/analytics/persist";
+import { sanitizeProperties } from "@/lib/analytics/sanitize";
+
+export async function trackServerError(
+  source: string,
+  error: unknown,
+  userId?: string | null,
+  metadata?: Record<string, unknown>
+): Promise<void> {
+  const message = error instanceof Error ? error.message : String(error);
+  const clean = sanitizeProperties({
+    ...metadata,
+    error_type: error instanceof Error ? error.name : "Error",
+  });
+
+  await Promise.allSettled([
+    persistAnalyticsError(source, message, userId ?? null, clean),
+    userId
+      ? captureServerEvent(userId, "app_error", { source, error_message: message.slice(0, 200), ...clean })
+      : Promise.resolve(),
+  ]);
+}

--- a/src/lib/analytics/track.ts
+++ b/src/lib/analytics/track.ts
@@ -36,13 +36,13 @@ function flushPending() {
   }
 }
 
-function sendToPersistApi(event: string, properties?: Record<string, unknown>) {
+function sendToPersistApi(event: string, properties?: Record<string, unknown>, attempt = 0) {
   if (typeof window === "undefined") return;
   const body = JSON.stringify({ event, properties: sanitizeProperties(properties) });
   try {
-    if (navigator.sendBeacon) {
-      navigator.sendBeacon("/api/analytics/track", new Blob([body], { type: "application/json" }));
-      return;
+    if (navigator.sendBeacon && attempt === 0) {
+      const ok = navigator.sendBeacon("/api/analytics/track", new Blob([body], { type: "application/json" }));
+      if (ok) return;
     }
   } catch {
     /* fall through */
@@ -52,7 +52,11 @@ function sendToPersistApi(event: string, properties?: Record<string, unknown>) {
     headers: { "Content-Type": "application/json" },
     body,
     keepalive: true,
-  }).catch(() => {});
+  }).catch(() => {
+    if (attempt < 2) {
+      window.setTimeout(() => sendToPersistApi(event, properties, attempt + 1), 1000 * (attempt + 1));
+    }
+  });
 }
 
 /** Track a product analytics event (PostHog + internal store). Non-blocking. */

--- a/src/lib/analytics/track.ts
+++ b/src/lib/analytics/track.ts
@@ -1,0 +1,139 @@
+import type { AnalyticsEvent, FeatureName } from "@/lib/analytics/events";
+import { getPostHogClient } from "@/lib/analytics/posthog-client";
+import { sanitizeProperties } from "@/lib/analytics/sanitize";
+
+const PENDING_KEY = "parenfy_analytics_pending";
+const MAX_PENDING = 50;
+
+type PendingEvent = { event: string; properties?: Record<string, unknown>; ts: number };
+
+function queuePending(event: string, properties?: Record<string, unknown>) {
+  if (typeof window === "undefined") return;
+  try {
+    const raw = localStorage.getItem(PENDING_KEY);
+    const list: PendingEvent[] = raw ? JSON.parse(raw) : [];
+    list.push({ event, properties, ts: Date.now() });
+    localStorage.setItem(PENDING_KEY, JSON.stringify(list.slice(-MAX_PENDING)));
+  } catch {
+    /* ignore */
+  }
+}
+
+function flushPending() {
+  if (typeof window === "undefined") return;
+  const ph = getPostHogClient();
+  if (!ph) return;
+  try {
+    const raw = localStorage.getItem(PENDING_KEY);
+    if (!raw) return;
+    const list: PendingEvent[] = JSON.parse(raw);
+    for (const item of list) {
+      ph.capture(item.event, sanitizeProperties(item.properties));
+    }
+    localStorage.removeItem(PENDING_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+function sendToPersistApi(event: string, properties?: Record<string, unknown>) {
+  if (typeof window === "undefined") return;
+  const body = JSON.stringify({ event, properties: sanitizeProperties(properties) });
+  try {
+    if (navigator.sendBeacon) {
+      navigator.sendBeacon("/api/analytics/track", new Blob([body], { type: "application/json" }));
+      return;
+    }
+  } catch {
+    /* fall through */
+  }
+  void fetch("/api/analytics/track", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+    keepalive: true,
+  }).catch(() => {});
+}
+
+/** Track a product analytics event (PostHog + internal store). Non-blocking. */
+export function trackEvent(event: AnalyticsEvent, properties?: Record<string, unknown>): void {
+  if (typeof window === "undefined") return;
+
+  const clean = sanitizeProperties(properties);
+  const ph = getPostHogClient();
+
+  if (ph) {
+    ph.capture(event, clean);
+    flushPending();
+  } else {
+    queuePending(event, clean);
+  }
+
+  sendToPersistApi(event, clean);
+
+  if (process.env.NODE_ENV === "development") {
+    console.debug("[analytics]", event, clean);
+  }
+}
+
+/** Track feature/page usage for popularity metrics. */
+export function trackFeatureUsed(feature: FeatureName, path?: string): void {
+  trackEvent("feature_used", { feature, path });
+}
+
+export type IdentifyTraits = {
+  email?: string | null;
+  signup_date?: string;
+  child_age?: string | null;
+  subscription_type?: string;
+};
+
+/** Identify logged-in user in PostHog (no child names or private notes). */
+export function identifyUser(userId: string, traits: IdentifyTraits): void {
+  if (typeof window === "undefined") return;
+  const ph = getPostHogClient();
+  if (!ph) return;
+
+  ph.identify(userId, sanitizeProperties({
+    email: traits.email ?? undefined,
+    signup_date: traits.signup_date,
+    child_age: traits.child_age ?? undefined,
+    subscription_type: traits.subscription_type ?? "free",
+  }));
+  flushPending();
+}
+
+export function resetAnalyticsIdentity(): void {
+  if (typeof window === "undefined") return;
+  getPostHogClient()?.reset();
+}
+
+export function trackClientError(
+  source: string,
+  message: string,
+  metadata?: Record<string, unknown>
+): void {
+  trackEvent("app_error", { source, error_message: message.slice(0, 200), ...metadata });
+  if (typeof window === "undefined") return;
+  const body = JSON.stringify({
+    source,
+    message: message.slice(0, 500),
+    metadata: sanitizeProperties(metadata),
+  });
+  try {
+    if (navigator.sendBeacon) {
+      navigator.sendBeacon("/api/analytics/error", new Blob([body], { type: "application/json" }));
+      return;
+    }
+  } catch {
+    /* fall through */
+  }
+  void fetch("/api/analytics/error", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+    keepalive: true,
+  }).catch(() => {});
+}
+
+export { flushPending as flushPendingAnalytics };

--- a/src/lib/auth-options.ts
+++ b/src/lib/auth-options.ts
@@ -5,6 +5,8 @@ import GitHubProvider from "next-auth/providers/github";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { compare } from "bcryptjs";
 import { prisma } from "@/lib/db";
+import { captureServerEvent } from "@/lib/analytics/posthog-server";
+import { persistAnalyticsEvent } from "@/lib/analytics/persist";
 
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma) as NextAuthOptions["adapter"],
@@ -58,6 +60,24 @@ export const authOptions: NextAuthOptions = {
   },
   session: {
     strategy: "jwt",
+  },
+  events: {
+    async signIn({ user, account }) {
+      if (!user.id) return;
+      const method = account?.provider ?? "credentials";
+      await Promise.allSettled([
+        persistAnalyticsEvent("login", user.id, { method }),
+        captureServerEvent(user.id, "login", { method }),
+      ]);
+    },
+    async signOut({ token }) {
+      const userId = token?.id as string | undefined;
+      if (!userId) return;
+      await Promise.allSettled([
+        persistAnalyticsEvent("logout", userId),
+        captureServerEvent(userId, "logout"),
+      ]);
+    },
   },
   callbacks: {
     async jwt({ token, user }) {

--- a/src/lib/services/founder-metrics.ts
+++ b/src/lib/services/founder-metrics.ts
@@ -1,0 +1,249 @@
+import { prisma } from "@/lib/db";
+import { startOfDay, subDays, format } from "date-fns";
+
+function countMap(rows: { key: string; count: bigint }[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const row of rows) {
+    out[row.key] = Number(row.count);
+  }
+  return out;
+}
+
+export async function getFounderMetrics() {
+  const now = new Date();
+  const todayStart = startOfDay(now);
+  const weekStart = subDays(todayStart, 7);
+  const monthStart = subDays(todayStart, 30);
+
+  const [
+    totalUsers,
+    newUsersToday,
+    usersWithOnboarding,
+    eventCounts,
+    dauRows,
+    wauRows,
+    mauRows,
+    recentErrors,
+    feedbackCount,
+    connectEvents,
+    connectRequests,
+    checkins,
+    allUsersGoals,
+    allUsersChallenges,
+    allChildAges,
+    featureUsage,
+    dailyActiveSeries,
+    dailySignupSeries,
+    topStories,
+    topMeals,
+    topActivities,
+  ] = await Promise.all([
+    prisma.user.count(),
+    prisma.user.count({ where: { createdAt: { gte: todayStart } } }),
+    prisma.user.count({ where: { onboardingComplete: true } }),
+    prisma.analyticsEvent.groupBy({
+      by: ["event"],
+      _count: { event: true },
+    }),
+    prisma.analyticsEvent.findMany({
+      where: { createdAt: { gte: todayStart }, userId: { not: null } },
+      distinct: ["userId"],
+      select: { userId: true },
+    }),
+    prisma.analyticsEvent.findMany({
+      where: { createdAt: { gte: weekStart }, userId: { not: null } },
+      distinct: ["userId"],
+      select: { userId: true },
+    }),
+    prisma.analyticsEvent.findMany({
+      where: { createdAt: { gte: monthStart }, userId: { not: null } },
+      distinct: ["userId"],
+      select: { userId: true },
+    }),
+    prisma.analyticsError.findMany({
+      orderBy: { createdAt: "desc" },
+      take: 15,
+      select: { id: true, source: true, message: true, createdAt: true },
+    }),
+    prisma.analyticsEvent.count({ where: { event: "feedback_submitted" } }),
+    prisma.connectEvent.count(),
+    prisma.connectRequest.count(),
+    prisma.analyticsEvent.count({ where: { event: "parent_checkin_completed" } }),
+    prisma.user.findMany({ select: { parentingGoals: true } }),
+    prisma.user.findMany({ select: { currentChallenges: true } }),
+    prisma.user.findMany({ where: { childAge: { not: null } }, select: { childAge: true } }),
+    prisma.$queryRaw<{ feature: string; count: bigint }[]>`
+      SELECT properties->>'feature' AS feature, COUNT(*)::bigint AS count
+      FROM "AnalyticsEvent"
+      WHERE event = 'feature_used' AND properties->>'feature' IS NOT NULL
+      GROUP BY properties->>'feature'
+      ORDER BY count DESC
+      LIMIT 10
+    `.catch(() => []),
+    prisma.$queryRaw<{ day: string; count: bigint }[]>`
+      SELECT to_char(date_trunc('day', "createdAt"), 'YYYY-MM-DD') AS day,
+             COUNT(DISTINCT "userId")::bigint AS count
+      FROM "AnalyticsEvent"
+      WHERE "createdAt" >= ${subDays(todayStart, 13)} AND "userId" IS NOT NULL
+      GROUP BY 1 ORDER BY 1
+    `.catch(() => []),
+    prisma.$queryRaw<{ day: string; count: bigint }[]>`
+      SELECT to_char(date_trunc('day', "createdAt"), 'YYYY-MM-DD') AS day,
+             COUNT(*)::bigint AS count
+      FROM "User"
+      WHERE "createdAt" >= ${subDays(todayStart, 13)}
+      GROUP BY 1 ORDER BY 1
+    `.catch(() => []),
+    prisma.analyticsEvent.findMany({
+      where: { event: { in: ["story_card_opened", "story_started", "story_saved"] } },
+      take: 200,
+      orderBy: { createdAt: "desc" },
+      select: { properties: true },
+    }),
+    prisma.analyticsEvent.findMany({
+      where: { event: { in: ["meal_card_opened", "meal_viewed", "meal_saved"] } },
+      take: 200,
+      orderBy: { createdAt: "desc" },
+      select: { properties: true },
+    }),
+    prisma.analyticsEvent.findMany({
+      where: { event: { in: ["activity_card_opened", "activity_started"] } },
+      take: 200,
+      orderBy: { createdAt: "desc" },
+      select: { properties: true },
+    }),
+  ]);
+
+  const events: Record<string, number> = {};
+  for (const row of eventCounts) {
+    events[row.event] = row._count.event;
+  }
+
+  const goalCounts: Record<string, number> = {};
+  for (const u of allUsersGoals) {
+    for (const g of u.parentingGoals) {
+      goalCounts[g] = (goalCounts[g] ?? 0) + 1;
+    }
+  }
+
+  const challengeCounts: Record<string, number> = {};
+  for (const u of allUsersChallenges) {
+    for (const c of u.currentChallenges) {
+      challengeCounts[c] = (challengeCounts[c] ?? 0) + 1;
+    }
+  }
+
+  const ageCounts: Record<string, number> = {};
+  for (const u of allChildAges) {
+    if (u.childAge) ageCounts[u.childAge] = (ageCounts[u.childAge] ?? 0) + 1;
+  }
+
+  const topFromProps = (rows: { properties: unknown }[], key: string) => {
+    const counts: Record<string, number> = {};
+    for (const row of rows) {
+      const props = row.properties as Record<string, unknown> | null;
+      const val = props?.[key];
+      if (typeof val === "string" && val.trim()) {
+        counts[val] = (counts[val] ?? 0) + 1;
+      }
+    }
+    return Object.entries(counts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([name, count]) => ({ name, count }));
+  };
+
+  const mumbotQuestions = events.mumbot_question_asked ?? 0;
+  const storiesRead = (events.story_started ?? 0) + (events.story_card_opened ?? 0);
+  const mealsViewed = (events.meal_viewed ?? 0) + (events.meal_card_opened ?? 0);
+  const activitiesStarted = (events.activity_started ?? 0) + (events.activity_card_opened ?? 0);
+
+  const featureMap = countMap(
+    featureUsage.map((r) => ({ key: r.feature || "Unknown", count: r.count }))
+  );
+  const mostUsedFeature =
+    Object.entries(featureMap).sort((a, b) => b[1] - a[1])[0]?.[0] ?? "—";
+
+  const returningUsers =
+    (events.day_1_return ?? 0) +
+    (events.day_3_return ?? 0) +
+    (events.day_7_return ?? 0) +
+    (events.day_30_return ?? 0);
+
+  const fillSeries = (rows: { day: string; count: bigint }[], days = 14) => {
+    const map = new Map(rows.map((r) => [r.day, Number(r.count)]));
+    const series: { day: string; count: number }[] = [];
+    for (let i = days - 1; i >= 0; i--) {
+      const d = format(subDays(todayStart, i), "yyyy-MM-dd");
+      series.push({ day: d, count: map.get(d) ?? 0 });
+    }
+    return series;
+  };
+
+  return {
+    summary: {
+      totalUsers,
+      newUsersToday,
+      dailyActiveUsers: dauRows.length,
+      weeklyActiveUsers: wauRows.length,
+      monthlyActiveUsers: mauRows.length,
+      onboardingCompleted: usersWithOnboarding,
+      onboardingRate: totalUsers > 0 ? Math.round((usersWithOnboarding / totalUsers) * 100) : 0,
+      avgMumbotQuestionsPerUser: totalUsers > 0 ? +(mumbotQuestions / totalUsers).toFixed(1) : 0,
+      storiesRead,
+      mealsViewed,
+      activitiesStarted,
+      connectRequests,
+      eventsCreated: connectEvents,
+      parentCheckins: checkins,
+      feedbackSubmitted: feedbackCount,
+      returningUsers,
+      mostUsedFeature,
+    },
+    events,
+    charts: {
+      dailyActiveUsers: fillSeries(dailyActiveSeries),
+      weeklySignups: fillSeries(dailySignupSeries),
+      featureUsage: Object.entries(featureMap).map(([feature, count]) => ({ feature, count })),
+      retention: [
+        { label: "Day 1", count: events.day_1_return ?? 0 },
+        { label: "Day 3", count: events.day_3_return ?? 0 },
+        { label: "Day 7", count: events.day_7_return ?? 0 },
+        { label: "Day 30", count: events.day_30_return ?? 0 },
+      ],
+      mumbotUsage: [
+        { label: "Questions", count: events.mumbot_question_asked ?? 0 },
+        { label: "Stories", count: events.mumbot_story_generated ?? 0 },
+        { label: "Recipes", count: events.mumbot_recipe_generated ?? 0 },
+        { label: "Activities", count: events.mumbot_activity_generated ?? 0 },
+      ],
+      connectUsage: [
+        { label: "Available today", count: events.available_today_created ?? 0 },
+        { label: "Events", count: events.event_created ?? 0 },
+        { label: "Join requests", count: events.event_join_requested ?? 0 },
+        { label: "Connections", count: events.connection_interest_sent ?? 0 },
+      ],
+    },
+    insights: {
+      topParentingGoals: Object.entries(goalCounts)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 8)
+        .map(([name, count]) => ({ name, count })),
+      topChallenges: Object.entries(challengeCounts)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 8)
+        .map(([name, count]) => ({ name, count })),
+      topChildAges: Object.entries(ageCounts)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 8)
+        .map(([name, count]) => ({ name, count })),
+      topStories: topFromProps(topStories, "title"),
+      topMeals: topFromProps(topMeals, "title"),
+      topActivities: topFromProps(topActivities, "title"),
+    },
+    recentErrors,
+    generatedAt: now.toISOString(),
+  };
+}
+
+export type FounderMetrics = Awaited<ReturnType<typeof getFounderMetrics>>;

--- a/src/lib/services/founder-metrics.ts
+++ b/src/lib/services/founder-metrics.ts
@@ -9,6 +9,20 @@ function countMap(rows: { key: string; count: bigint }[]): Record<string, number
   return out;
 }
 
+async function avgOnboardingDuration(): Promise<number | null> {
+  const rows = await prisma.analyticsEvent.findMany({
+    where: { event: "onboarding_completed" },
+    select: { properties: true },
+    take: 200,
+    orderBy: { createdAt: "desc" },
+  });
+  const durations = rows
+    .map((r) => (r.properties as { duration_seconds?: number })?.duration_seconds)
+    .filter((n): n is number => typeof n === "number" && n > 0);
+  if (!durations.length) return null;
+  return Math.round(durations.reduce((a, b) => a + b, 0) / durations.length);
+}
+
 export async function getFounderMetrics() {
   const now = new Date();
   const todayStart = startOfDay(now);
@@ -190,6 +204,15 @@ export async function getFounderMetrics() {
       onboardingCompleted: usersWithOnboarding,
       onboardingRate: totalUsers > 0 ? Math.round((usersWithOnboarding / totalUsers) * 100) : 0,
       avgMumbotQuestionsPerUser: totalUsers > 0 ? +(mumbotQuestions / totalUsers).toFixed(1) : 0,
+      avgEventsPerActiveUserToday:
+        dauRows.length > 0
+          ? +(
+              (await prisma.analyticsEvent.count({
+                where: { createdAt: { gte: todayStart }, userId: { not: null } },
+              })) / dauRows.length
+            ).toFixed(1)
+          : 0,
+      avgOnboardingSeconds: await avgOnboardingDuration(),
       storiesRead,
       mealsViewed,
       activitiesStarted,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements PostHog product analytics and an internal founder dashboard so Parenfy is measurable during beta — **no UI redesign and no new user-facing features**.

## PostHog setup

Add to Vercel:

- `NEXT_PUBLIC_POSTHOG_KEY` — PostHog project API key
- `NEXT_PUBLIC_POSTHOG_HOST` — e.g. `https://us.i.posthog.com` (or EU cloud URL)
- `FOUNDER_ADMIN_EMAILS` — comma-separated admin emails for `/admin/founder`
- Optional: `POSTHOG_KEY` for server-side capture

## What's included

### Analytics infrastructure
- `posthog-js` client + `posthog-node` server helpers
- Reusable `trackEvent`, `identifyUser`, `trackReturnVisit`, `trackClientError`
- GDPR-safe property sanitization (no child names, messages, passwords, tokens)
- Session replay with masked inputs
- Async event persistence to Neon with retry on failure

### Events tracked
Full coverage across auth, onboarding (with duration), Today, MumBot, stories/meals/activities/language, Connect, parent check-in, retention, feature usage, feedback sentiment, and errors.

### Founder dashboard (admin only)
`/admin/founder` — DAU/WAU/MAU, signups, feature usage, retention, MumBot/Connect usage, top goals/challenges/ages, avg events per DAU, avg onboarding time, recent errors.

### PostHog funnels
`$pageview` events captured on navigation — build funnels in PostHog UI (Signup → Onboarding → Today → MumBot → Day 7 return).

## How to test

1. Set PostHog env vars + your email in `FOUNDER_ADMIN_EMAILS`
2. Deploy and use the app — verify events in PostHog Live Events
3. Visit `/admin/founder` as an admin user
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a231d1e6-caff-4d6d-acd3-83f350fa4fb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a231d1e6-caff-4d6d-acd3-83f350fa4fb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

